### PR TITLE
Fix: Allow 'any' to be used in firewall rule creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,37 @@
 
 **Topics**
 
-- <a href="#v1-2-0">v1\.2\.0</a>
+- <a href="#v1-2-1">v1\.2\.1</a>
     - <a href="#release-summary">Release Summary</a>
+    - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v1-2-0">v1\.2\.0</a>
+    - <a href="#release-summary-1">Release Summary</a>
     - <a href="#new-modules">New Modules</a>
 - <a href="#v1-1-0">v1\.1\.0</a>
-    - <a href="#release-summary-1">Release Summary</a>
+    - <a href="#release-summary-2">Release Summary</a>
     - <a href="#new-modules-1">New Modules</a>
 - <a href="#v1-0-0">v1\.0\.0</a>
-    - <a href="#release-summary-2">Release Summary</a>
+    - <a href="#release-summary-3">Release Summary</a>
     - <a href="#new-modules-2">New Modules</a>
+
+<a id="v1-2-1"></a>
+## v1\.2\.1
+
+<a id="release-summary"></a>
+### Release Summary
+
+Minor bug fixes
+
+<a id="bugfixes"></a>
+### Bugfixes
+
+* Allow use of \'any\' keyword for src/dst networks and services for sfos\_firewall\_rule module
+* Fixed documentation error in examples for sfos\_zone
 
 <a id="v1-2-0"></a>
 ## v1\.2\.0
 
-<a id="release-summary"></a>
+<a id="release-summary-1"></a>
 ### Release Summary
 
 This release adds modules for working with IPS and Syslog settings
@@ -29,7 +46,7 @@ This release adds modules for working with IPS and Syslog settings
 <a id="v1-1-0"></a>
 ## v1\.1\.0
 
-<a id="release-summary-1"></a>
+<a id="release-summary-2"></a>
 ### Release Summary
 
 This release contains new modules for working with the SNMP agent and SNMPv3 users on Sophos Firewall
@@ -43,7 +60,7 @@ This release contains new modules for working with the SNMP agent and SNMPv3 use
 <a id="v1-0-0"></a>
 ## v1\.0\.0
 
-<a id="release-summary-2"></a>
+<a id="release-summary-3"></a>
 ### Release Summary
 
 This is the first proper release of the <code>sophos\.sophos\_firewall</code> collection\.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -94,3 +94,13 @@ releases:
       name: sfos_syslog
       namespace: ''
     release_date: '2024-11-01'
+  1.2.1:
+    changes:
+      bugfixes:
+      - Allow use of 'any' keyword for src/dst networks and services for sfos_firewall_rule
+        module
+      - Fixed documentation error in examples for sfos_zone
+      release_summary: Minor bug fixes
+    fragments:
+    - 1.2.1.yaml
+    release_date: '2024-12-04'

--- a/plugins/modules/sfos_firewall_rule.py
+++ b/plugins/modules/sfos_firewall_rule.py
@@ -195,6 +195,27 @@ def create_firewallrule(fw_obj, module, result):
     Returns:
         dict: API response
     """
+    src_zones = module.params.get("src_zones")
+    if src_zones:
+        if "any" in [item.lower() for item in src_zones]:
+            src_zones = []
+    dst_zones = module.params.get("dst_zones")
+    if dst_zones:
+        if "any" in [item.lower() for item in dst_zones]:
+            dst_zones = []
+    src_networks = module.params.get("src_networks")
+    if src_networks:
+        if "any" in [item.lower() for item in src_networks]:
+            src_networks = []
+    dst_networks = module.params.get("dst_networks")
+    if dst_networks:
+        if "any" in [item.lower() for item in dst_networks]:
+            dst_networks = []
+    service_list = module.params.get("service_list")
+    if service_list:
+        if "any" in [item.lower() for item in service_list]:
+            service_list = []
+
     rule_params = {
         "rulename": module.params.get("name"),
         "status": module.params.get("status").capitalize()
@@ -212,11 +233,11 @@ def create_firewallrule(fw_obj, module, result):
         if module.params.get("log")
         else None,
         "description": module.params.get("description"),
-        "src_zones": module.params.get("src_zones"),
-        "dst_zones": module.params.get("dst_zones"),
-        "src_networks": module.params.get("src_networks"),
-        "dst_networks": module.params.get("dst_networks"),
-        "service_list": module.params.get("service_list"),
+        "src_zones": src_zones,
+        "dst_zones": dst_zones,
+        "src_networks": src_networks,
+        "dst_networks": dst_networks,
+        "service_list": service_list,
     }
 
     try:

--- a/plugins/modules/sfos_zone.py
+++ b/plugins/modules/sfos_zone.py
@@ -161,7 +161,7 @@ author:
 
 EXAMPLES = r"""
 - name: Create Zone
-  sophos.sophos_firewall.sfos_firewall_rule:
+  sophos.sophos_firewall.sfos_zone:
     username: "{{ username }}"
     password: "{{ password }}"
     hostname: myfirewallhostname.sophos.net
@@ -173,7 +173,7 @@ EXAMPLES = r"""
     state: present
 
 - name: Display Existing Zone
-  sophos.sophos_firewall.sfos_firewall_rule:
+  sophos.sophos_firewall.sfos_zone:
     username: "{{ username }}"
     password: "{{ password }}"
     hostname: myfirewallhostname.sophos.net
@@ -183,7 +183,7 @@ EXAMPLES = r"""
     state: query
 
 - name: Update Zone Admin Services
-  sophos.sophos_firewall.sfos_firewall_rule:
+  sophos.sophos_firewall.sfos_zone:
     username: "{{ username }}"
     password: "{{ password }}"
     hostname: myfirewallhostname.sophos.net
@@ -195,7 +195,7 @@ EXAMPLES = r"""
     state: updated
 
 - name: Remove Zone
-  sophos.sophos_firewall.sfos_firewall_rule:
+  sophos.sophos_firewall.sfos_zone:
     username: "{{ username }}"
     password: "{{ password }}"
     hostname: myfirewallhostname.sophos.net

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophosfirewall-ansible"
-version = "1.2.0"
+version = "1.2.1"
 description = "Ansible modules for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 license = "GNU GENERAL PUBLIC LICENSE"

--- a/tests/integration/targets/sfos_firewall_rule/tasks/main.yml
+++ b/tests/integration/targets/sfos_firewall_rule/tasks/main.yml
@@ -23,11 +23,14 @@
       verify: "{{ sfos_verify }}"
   no_log: true
 
-- name: ENSURE IGT_TESTRULE DOES NOT EXIST
+- name: ENSURE TEST RULES DO NOT EXIST
   sophos.sophos_firewall.sfos_firewall_rule:
     <<: *sfos_connection_params
-    name: IGT_TESTRULE
+    name: "{{ item }}"
     state: absent
+  loop:
+    - IGT_TESTRULE
+    - IGT_TESTRULE_ANY
 
 - name: CREATE NETWORKS
   sophos.sophos_firewall.sfos_ip_host:
@@ -88,6 +91,48 @@
       - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['SourceNetworks']['Network'] == "IGT_TESTNETWORK1"
       - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['DestinationNetworks']['Network'] == "IGT_TESTNETWORK2"
       - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['Services']['Service'] == "HTTPS"
+
+- name: CREATE FIREWALL RULE USING ANY
+  sophos.sophos_firewall.sfos_firewall_rule:
+    <<: *sfos_connection_params
+    name: IGT_TESTRULE_ANY
+    position: bottom
+    status: enable
+    src_networks:
+      - Any
+    dst_networks:
+      - Any
+    service_list:
+      - Any
+    action: accept
+    state: present
+  register: create_any
+
+- name: ASSERTION CHECK FOR CREATE FIREWALL RULE USING ANY
+  assert:
+    that: 
+      - create_any is changed
+      - create_any['api_response']['Response']['FirewallRule']['Status']['@code'] == "200"
+      - create_any['api_response']['Response']['FirewallRule']['Status']['#text'] == "Configuration applied successfully."
+
+- name: QUERY FIREWALL RULE USING ANY
+  sophos.sophos_firewall.sfos_firewall_rule:
+    <<: *sfos_connection_params
+    name: IGT_TESTRULE_ANY
+    state: query
+  register: query_rule_any
+
+- name: ASSERTION CHECK FOR QUERY FIREWALL RULE USING ANY
+  assert:
+    that: 
+      - query_rule_any is not changed
+      - query_rule_any['api_response']['Response']['FirewallRule']['Name'] == "IGT_TESTRULE_ANY"
+      - query_rule_any['api_response']['Response']['FirewallRule']['Status'] == "Enable"
+      - query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']['Action'] == "Accept"
+      - "'SourceNetworks' not in query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']"
+      - "'DestinationNetworks' not in query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']"
+      - "'Services' not in query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']"
+
 
 - name: CREATE EXISTING FIREWALL RULE
   sophos.sophos_firewall.sfos_firewall_rule:
@@ -187,6 +232,13 @@
     that: 
       - update_nonexist is failed
       - update_nonexist['api_response'] == "No. of records Zero."
+
+- name: REMOVE IGT_TESTRULE_ANY
+  sophos.sophos_firewall.sfos_firewall_rule:
+    <<: *sfos_connection_params
+    name: IGT_TESTRULE_ANY
+    state: absent
+  register: remove_rule
 
 - name: REMOVE TEST NETWORKS
   sophos.sophos_firewall.sfos_ip_host:


### PR DESCRIPTION
- Allows the 'any' keyword to be used for src/dest networks or services when creating firewall rules
- Fixes examples for sfos_zone