### PR TITLE
feat: sfos_firewall_rulegroup module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,47 @@
 
 **Topics**
 
-- <a href="#v1-3-0">v1\.3\.0</a>
-    - <a href="#new-modules">New Modules</a>
-- <a href="#v1-2-1">v1\.2\.1</a>
+- <a href="#v1-4-0">v1\.4\.0</a>
     - <a href="#release-summary">Release Summary</a>
-    - <a href="#bugfixes">Bugfixes</a>
-- <a href="#v1-2-0">v1\.2\.0</a>
+    - <a href="#new-modules">New Modules</a>
+- <a href="#v1-3-0">v1\.3\.0</a>
     - <a href="#release-summary-1">Release Summary</a>
     - <a href="#new-modules-1">New Modules</a>
-- <a href="#v1-1-0">v1\.1\.0</a>
+- <a href="#v1-2-1">v1\.2\.1</a>
     - <a href="#release-summary-2">Release Summary</a>
-    - <a href="#new-modules-2">New Modules</a>
-- <a href="#v1-0-0">v1\.0\.0</a>
+    - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v1-2-0">v1\.2\.0</a>
     - <a href="#release-summary-3">Release Summary</a>
+    - <a href="#new-modules-2">New Modules</a>
+- <a href="#v1-1-0">v1\.1\.0</a>
+    - <a href="#release-summary-4">Release Summary</a>
     - <a href="#new-modules-3">New Modules</a>
+- <a href="#v1-0-0">v1\.0\.0</a>
+    - <a href="#release-summary-5">Release Summary</a>
+    - <a href="#new-modules-4">New Modules</a>
+
+<a id="v1-4-0"></a>
+## v1\.4\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+This release introduces a new module for working with firewall rule groups\.
+
+<a id="new-modules"></a>
+### New Modules
+
+* sophos\.sophos\_firewall\.sfos\_firewall\_rulegroup \- Manage Firewall Rules \(Protect \> Rules \& policies\)\.
 
 <a id="v1-3-0"></a>
 ## v1\.3\.0
 
-<a id="new-modules"></a>
+<a id="release-summary-1"></a>
+### Release Summary
+
+This release adds modules for working with authentication servers
+
+<a id="new-modules-1"></a>
 ### New Modules
 
 * sophos\.sophos\_firewall\.sfos\_authentication\_ad \- Manage Authentication settings Active Directory\.
@@ -33,7 +55,7 @@
 <a id="v1-2-1"></a>
 ## v1\.2\.1
 
-<a id="release-summary"></a>
+<a id="release-summary-2"></a>
 ### Release Summary
 
 Minor bug fixes
@@ -47,12 +69,12 @@ Minor bug fixes
 <a id="v1-2-0"></a>
 ## v1\.2\.0
 
-<a id="release-summary-1"></a>
+<a id="release-summary-3"></a>
 ### Release Summary
 
 This release adds modules for working with IPS and Syslog settings
 
-<a id="new-modules-1"></a>
+<a id="new-modules-2"></a>
 ### New Modules
 
 * sophos\.sophos\_firewall\.sfos\_ips \- Manage IPS protection \(Protect \> Intrusion Protection \> IPS policies\)\.
@@ -61,12 +83,12 @@ This release adds modules for working with IPS and Syslog settings
 <a id="v1-1-0"></a>
 ## v1\.1\.0
 
-<a id="release-summary-2"></a>
+<a id="release-summary-4"></a>
 ### Release Summary
 
 This release contains new modules for working with the SNMP agent and SNMPv3 users on Sophos Firewall
 
-<a id="new-modules-2"></a>
+<a id="new-modules-3"></a>
 ### New Modules
 
 * sophos\.sophos\_firewall\.sfos\_snmp\_agent \- Manage SNMP Agent \(System \> Administration \> SNMP\)\.
@@ -75,12 +97,12 @@ This release contains new modules for working with the SNMP agent and SNMPv3 use
 <a id="v1-0-0"></a>
 ## v1\.0\.0
 
-<a id="release-summary-3"></a>
+<a id="release-summary-5"></a>
 ### Release Summary
 
 This is the first proper release of the <code>sophos\.sophos\_firewall</code> collection\.
 
-<a id="new-modules-3"></a>
+<a id="new-modules-4"></a>
 ### New Modules
 
 * sophos\.sophos\_firewall\.sfos\_admin\_settings \- Manage Admin and user settings \(System \> Administration\)\.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -127,3 +127,14 @@ releases:
       name: sfos_authentication_tacacs
       namespace: ''
     release_date: '2024-12-06'
+  1.4.0:
+    changes:
+      release_summary: This release introduces a new module for working with firewall
+        rule groups.
+    fragments:
+    - 1.4.0.yaml
+    modules:
+    - description: Manage Firewall Rules (Protect > Rules & policies).
+      name: sfos_firewall_rulegroup
+      namespace: ''
+    release_date: '2024-12-13'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: sophos
 name: sophos_firewall
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.0
+version: 1.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/sfos_firewall_rulegroup.py
+++ b/plugins/modules/sfos_firewall_rulegroup.py
@@ -1,0 +1,309 @@
+#!/usr/bin/python
+
+# Copyright 2024 Sophos Ltd.  All rights reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: sfos_firewall_rulegroup
+
+short_description: Manage Firewall Rules (Protect > Rules & policies)
+
+version_added: "1.4.0"
+
+description: Creates, updates or removes firewall rule groups (Protect > Rules & policies) on Sophos Firewall
+
+extends_documentation_fragment:
+  - sophos.sophos_firewall.fragments.base
+
+options:
+    name:
+        description: Name of the firewall rule group to create, update, or delete
+        required: true
+        type: str
+    description:
+        description: Rule group description
+        type: str
+        required: false
+    policy_list:
+        description: List of firewall rules to be added to the group
+        type: list
+        elements: str
+        required: false
+    source_zones:
+        description:
+            - Source zones for the rule group
+        required: false
+        type: list
+        elements: str
+    dest_zones:
+        description:
+            - Destination zones for the rule group
+        required: false
+        type: str
+        elements: str
+    policy_type:
+        description:
+            - Type of policy
+        choices: ["User/network rule", "Network rule", "User rule", "WAF rule", "Any"]
+        required: false
+        type: str
+        default: "Any"
+    source_zone_action:
+        description:
+            - Indicate whether adding to, removing from, or replacing the list of source zones. Default is add.
+        choices: ["add", "remove", "replace"]
+        required: false
+        type: str
+        default: add
+    dest_zone_action:
+        description:
+            - Indicate whether adding to, removing from, or replacing the list of destination zones. Default is add.
+        choices: ["add", "remove", "replace"]
+        required: false
+        type: str
+        default: add
+    state:
+        description:
+            - Use C(query) to retrieve, C(present) to create, C(absent) to remove, or C(updated) to modify
+        choices: [present, updated, query]
+        type: str
+        required: true
+
+author:
+    - Matt Mullen (@mamullen13316)
+"""
+
+EXAMPLES = r"""
+- name: Create Firewall Rule Group
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    username: "{{ username }}"
+    password: "{{ password }}"
+    hostname: myfirewallhostname.sophos.net
+    port: 4444
+    verify: false
+    name: TEST RULEGROUP
+    description: Test rule group created by Ansible
+    policy_list:
+      - TEST RULE 1
+      - TEST RULE 2
+    policy_type: Any
+    source_zones:
+      - LAN
+    dest_zones:
+      - WAN
+    state: present
+"""
+
+RETURN = r"""
+api_response:
+    description: Serialized object containing the API response.
+    type: dict
+    returned: always
+
+"""
+
+try:
+    from sophosfirewall_python.firewallapi import (
+        SophosFirewall,
+        SophosFirewallZeroRecords,
+        SophosFirewallAuthFailure,
+        SophosFirewallAPIError,
+    )
+    from requests.exceptions import RequestException
+
+    PREREQ_MET = {"result": True}
+except ImportError as errMsg:
+    PREREQ_MET = {"result": False, "missing_module": errMsg.name}
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import missing_required_lib
+
+
+def get_firewallrulegroup(fw_obj, module, result):
+    """Get firewall rule group from Sophos Firewall
+
+    Args:
+        fw_obj (SophosFirewall): SophosFirewall object
+        module (AnsibleModule): AnsibleModule object
+        result (dict): Result output to be sent to the console
+
+    Returns:
+        dict: Results of lookup
+    """
+    try:
+        resp = fw_obj.get_rulegroup(name=module.params.get("name"))
+    except SophosFirewallZeroRecords as error:
+        return {"exists": False, "api_response": str(error)}
+    except SophosFirewallAuthFailure as error:
+        module.fail_json(msg="Authentication error: {0}".format(error), **result)
+    except SophosFirewallAPIError as error:
+        module.fail_json(msg="API Error: {0}".format(error), **result)
+    except RequestException as error:
+        module.fail_json(msg="Error communicating to API: {0}".format(error), **result)
+
+    return {"exists": True, "api_response": resp}
+
+
+def create_firewallrulegroup(fw_obj, module, result):
+    """Create a firewall rule group on Sophos Firewall.
+
+    Args:
+        fw_obj (SophosFirewall): SophosFirewall object
+        module (AnsibleModule): AnsibleModule object
+        result (dict): Result output to be sent to the console
+
+    Returns:
+        dict: API response
+    """
+    params = dict(
+        name=module.params.get("name"),
+        description=module.params.get("description"),
+        policy_list=module.params.get("policy_list"),
+        source_zones=module.params.get("source_zones"),
+        dest_zones=module.params.get("dest_zones"),
+        policy_type=module.params.get("policy_type")
+    )
+    try:
+        resp = fw_obj.create_rulegroup(**params)
+    except SophosFirewallAuthFailure as error:
+        module.fail_json(msg="Authentication error: {0}".format(error), **result)
+    except SophosFirewallAPIError as error:
+        module.fail_json(msg="API Error: {0}".format(error), **result)
+    except RequestException as error:
+        module.fail_json(msg="Error communicating to API: {0}".format(error), **result)
+    else:
+        return resp
+
+
+def update_firewallrulegroup(fw_obj, module, result):
+    """Update an existing firewall rule group on Sophos Firewall
+
+    Args:
+        fw_obj (SophosFirewall): SophosFirewall object
+        module (AnsibleModule): AnsibleModule object
+        result (dict): Result output to be sent to the console
+
+    Returns:
+        dict: API response
+    """
+    params = dict(
+        name=module.params.get("name"),
+        description=module.params.get("description"),
+        policy_list=module.params.get("policy_list"),
+        source_zones=module.params.get("source_zones"),
+        dest_zones=module.params.get("dest_zones"),
+        policy_type=module.params.get("policy_type"),
+        source_zone_action=module.params.get("source_zone_action"),
+        dest_zone_action=module.params.get("dest_zone_action")
+    )
+
+    try:
+        resp = fw_obj.update_rulegroup(**params)
+    except SophosFirewallAuthFailure as error:
+        module.fail_json(msg="Authentication error: {0}".format(error), **result)
+    except SophosFirewallAPIError as error:
+        module.fail_json(msg="API Error: {0}".format(error), **result)
+    except RequestException as error:
+        module.fail_json(msg="Error communicating to API: {0}".format(error), **result)
+    else:
+        return resp
+
+
+def main():
+    """Code executed at run time."""
+    argument_spec = {
+        "username": {"required": True},
+        "password": {"required": True, "no_log": True},
+        "hostname": {"required": True},
+        "port": {"type": "int", "default": 4444},
+        "verify": {"type": "bool", "default": True},
+        "name": {"type": "str", "required": True},
+        "description": {"type": "str"},
+        "policy_list": {"type": "list", "elements": "str"},
+        "source_zones": {"type": "list", "elements": "str"},
+        "dest_zones": {"type": "list", "elements": "str"},
+        "policy_type": {"type": "str", "choices": ["User/network rule", "Network rule", "User rule", "WAF rule", "Any"]},
+        "source_zone_action": {"type": "str", "choices": ["add", "remove", "replace"], "default": "add"},
+        "dest_zone_action": {"type": "str", "choices": ["add", "remove", "replace"], "default": "add"},
+        "state": {
+            "required": True,
+            "choices": ["present", "updated", "query"],
+        },
+    }
+
+    required_if = [
+        ("state", "present", ("policy_list", "source_zones", "dest_zones",), True),
+    ]
+
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=required_if,
+        supports_check_mode=True,
+    )
+
+    if not PREREQ_MET["result"]:
+        module.fail_json(msg=missing_required_lib(PREREQ_MET["missing_module"]))
+
+    fw = SophosFirewall(
+        username=module.params.get("username"),
+        password=module.params.get("password"),
+        hostname=module.params.get("hostname"),
+        port=module.params.get("port"),
+        verify=module.params.get("verify"),
+    )
+
+    result = {"changed": False, "check_mode": False}
+
+    state = module.params.get("state")
+
+    exist_check = get_firewallrulegroup(fw, module, result)
+    result["api_response"] = exist_check["api_response"]
+
+    if state == "query":
+        module.exit_json(**result)
+
+    if module.check_mode:
+        result["check_mode"] = True
+        module.exit_json(**result)
+
+    if state == "present" and not exist_check["exists"]:
+        api_response = create_firewallrulegroup(fw, module, result)
+        if (
+            api_response["Response"]["FirewallRuleGroup"]["Status"]["#text"]
+            == "Configuration applied successfully."
+        ):
+            result["changed"] = True
+            result["api_response"] = api_response
+
+    elif state == "present" and exist_check["exists"]:
+        result["changed"] = False
+
+    elif state == "updated" and exist_check["exists"]:
+        api_response = update_firewallrulegroup(fw, module, result)
+
+        if api_response:
+            if (
+                api_response["Response"]["FirewallRuleGroup"]["Status"]["#text"]
+                == "Configuration applied successfully."
+            ):
+                result["changed"] = True
+            result["api_response"] = api_response
+        else:
+            result["changed"] = False
+
+    elif state == "updated" and not exist_check["exists"]:
+        result["changed"] = False
+        module.fail_json(exist_check["api_response"], **result)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophosfirewall-ansible"
-version = "1.3.0"
+version = "1.4.0"
 description = "Ansible modules for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 license = "GNU GENERAL PUBLIC LICENSE"

--- a/tests/integration/targets/sfos_firewall_rulegroup/tasks/main.yml
+++ b/tests/integration/targets/sfos_firewall_rulegroup/tasks/main.yml
@@ -1,0 +1,253 @@
+# Copyright 2023 Sophos Ltd.  All rights reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+- name: CHECK VARS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure these variables are set in tests/integration/integration_config.yml: 
+      sfos_username, sfos_password, sfos_hostname, sfos_port, sfos_verify
+  when: sfos_username is not defined or
+        sfos_password is not defined or
+        sfos_hostname is not defined or
+        sfos_port is not defined or
+        sfos_verify is not defined
+
+- name: SET VARS
+  set_fact:
+    sfos_connection_params: &sfos_connection_params
+      username: "{{ sfos_username }}"
+      password: "{{ sfos_password }}"
+      hostname: "{{ sfos_hostname }}"
+      port: "{{ sfos_port }}"
+      verify: "{{ sfos_verify }}"
+  no_log: true
+
+- name: ENSURE TEST RULES DO NOT EXIST
+  sophos.sophos_firewall.sfos_firewall_rule:
+    <<: *sfos_connection_params
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - IGT_TESTRULE1
+    - IGT_TESTRULE2
+
+# When the test rules are deleted, the group will be automatically deleted.
+# This is the behavior in the UI, once all rules are removed from the group the group is gone.
+
+- name: CREATE NETWORKS
+  sophos.sophos_firewall.sfos_ip_host:
+    <<: *sfos_connection_params
+    name: "{{ item.name }}"
+    network: "{{ item.ip_address }}"
+    mask: "{{ item.mask }}"
+    host_type: network
+    state: present   
+  loop:
+    - name: IGT_TESTNETWORK1
+      ip_address: 1.1.1.0
+      mask: 255.255.255.0
+    - name: IGT_TESTNETWORK2
+      ip_address: 2.2.2.0
+      mask: 255.255.255.0
+    - name: IGT_TESTNETWORK3
+      ip_address: 3.3.3.0
+      mask: 255.255.255.0
+    
+- name: CREATE FIREWALL RULES
+  sophos.sophos_firewall.sfos_firewall_rule:
+    <<: *sfos_connection_params
+    name: "{{ item.name }}"
+    position: bottom
+    status: enable
+    src_networks:
+      - "{{ item.src_network }}"
+    dst_networks:
+      - "{{ item.dst_network }}"
+    service_list:
+      - HTTPS
+    action: accept
+    state: present
+  register: create_rule
+  loop:
+    - name: IGT_TESTRULE1
+      src_network: IGT_TESTNETWORK1
+      dst_network: IGT_TESTNETWORK2
+    - name: IGT_TESTRULE2
+      src_network: IGT_TESTNETWORK1
+      dst_network: IGT_TESTNETWORK3
+
+- name: CREATE FIREWALL RULE GROUP
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    description: Test rule group created during Ansible integration testing
+    policy_list:
+      - IGT_TESTRULE1
+    policy_type: Any
+    source_zones:
+      - LAN
+    dest_zones:
+      - WAN
+    state: present
+
+- name: QUERY FIREWALL RULE GROUP
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    state: query
+  register: query_rulegroup
+
+- name: ASSERTION CHECK FOR QUERY FIREWALL RULE GROUP
+  assert:
+    that: 
+      - query_rulegroup is not changed
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Name'] == "IGT_TESTGROUP"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Description'] == "Test rule group created during Ansible integration testing"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['SecurityPolicyList']['SecurityPolicy'] == "IGT_TESTRULE1"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['SourceZones']['Zone'] == "LAN"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['DestinationZones']['Zone'] == "WAN"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Policytype'] == "Any"
+
+- name: CREATE EXISTING FIREWALL RULE GROUP
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    description: Test rule group created during Ansible integration testing
+    policy_list:
+      - IGT_TESTRULE1
+    policy_type: Any
+    source_zones:
+      - LAN
+    dest_zones:
+      - WAN
+    state: present
+  register: create_existing
+
+- name: ASSERTION CHECK FOR CREATE EXISTING FIREWALL RULE 
+  assert:
+    that: 
+      - create_existing is not changed
+      - create_existing['api_response']['Response']['FirewallRuleGroup']['Name'] == "IGT_TESTGROUP"
+
+- name: ADD RULE TO RULE GROUP
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    policy_list:
+      - IGT_TESTRULE2
+    state: updated
+  register: update_rule
+
+- name: ASSERTION CHECK FOR ADD RULE TO RULE GROUP
+  assert:
+    that: 
+      - update_rule is changed
+      - update_rule['api_response']['Response']['FirewallRuleGroup']['Status']['@code'] == "200"
+      - update_rule['api_response']['Response']['FirewallRuleGroup']['Status']['#text'] == "Configuration applied successfully."
+
+- name: QUERY FIREWALL RULE GROUP FOR ADD RULE TO RULE GROUP
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    state: query
+  register: query_rulegroup
+
+- name: ASSERTION CHECK FOR ADD RULE TO RULE GROUP
+  assert:
+    that: 
+      - query_rulegroup is not changed
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Name'] == "IGT_TESTGROUP"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Description'] == "Test rule group created during Ansible integration testing"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['SecurityPolicyList']['SecurityPolicy'] == ['IGT_TESTRULE2', 'IGT_TESTRULE1']
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['SourceZones']['Zone'] == "LAN"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['DestinationZones']['Zone'] == "WAN"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Policytype'] == "Any"
+
+- name: ADD ZONES
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    source_zones:
+      - DMZ
+    dest_zones:
+      - VPN
+    state: updated
+  register: update_rulegroup
+
+- name: ASSERTION CHECK FOR ADD ZONES
+  assert:
+    that: 
+      - update_rulegroup is changed
+      - update_rulegroup['api_response']['Response']['FirewallRuleGroup']['Status']['@code'] == "200"
+      - update_rulegroup['api_response']['Response']['FirewallRuleGroup']['Status']['#text'] == "Configuration applied successfully."
+
+- name: QUERY FIREWALL RULE GROUP FOR ADD ZONES
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_TESTGROUP
+    state: query
+  register: query_rulegroup
+
+- name: ASSERTION CHECK FOR ADD ZONES
+  assert:
+    that: 
+      - query_rulegroup is not changed
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Name'] == "IGT_TESTGROUP"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Description'] == "Test rule group created during Ansible integration testing"
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['SecurityPolicyList']['SecurityPolicy'] == ['IGT_TESTRULE2', 'IGT_TESTRULE1']
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['SourceZones']['Zone'] == ['DMZ', 'LAN']
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['DestinationZones']['Zone'] == ['WAN', 'VPN']
+      - query_rulegroup['api_response']['Response']['FirewallRuleGroup']['Policytype'] == "Any"
+
+
+- name: REMOVE IGT_TESTRULE
+  sophos.sophos_firewall.sfos_firewall_rule:
+    <<: *sfos_connection_params
+    name: "{{ item }}"
+    state: absent
+  register: remove_rule
+  loop:
+    - IGT_TESTRULE1
+    - IGT_TESTRULE2
+
+# - name: ASSERTION CHECK FOR REMOVE IGT_TESTRULE
+#   assert:
+#     that: 
+#       - remove_rule is changed
+#       - remove_rule['api_response']['Response']['FirewallRule']['Status']['@code'] == "200"
+#       - remove_rule['api_response']['Response']['FirewallRule']['Status']['#text'] == "Configuration applied successfully."
+#   loop:
+#     - remove_rule
+
+- name: QUERY FOR IGT_RULEGROUP NONEXISTING
+  sophos.sophos_firewall.sfos_firewall_rulegroup:
+    <<: *sfos_connection_params
+    name: IGT_RULEGROUP
+    state: query
+  register: query_nonexist
+
+- name: ASSERTION CHECK FOR QUERY IGT_RULEGROUP
+  assert:
+    that: 
+      - query_nonexist is not changed
+      - query_nonexist['api_response'] == "No. of records Zero."
+
+- name: REMOVE TEST NETWORKS
+  sophos.sophos_firewall.sfos_ip_host:
+    <<: *sfos_connection_params
+    name: "{{ item.name }}"
+    network: "{{ item.ip_address }}"
+    mask: "{{ item.mask }}"
+    state: absent
+    host_type: network
+  loop:
+    - name: IGT_TESTNETWORK1
+      ip_address: 1.1.1.0
+      mask: 255.255.255.0
+    - name: IGT_TESTNETWORK2
+      ip_address: 2.2.2.0
+      mask: 255.255.255.0
+    - name: IGT_TESTNETWORK3
+      ip_address: 3.3.3.0
+      mask: 255.255.255.0

--- a/tests/manual/sfos_firewall_rulegroup.yml
+++ b/tests/manual/sfos_firewall_rulegroup.yml
@@ -1,0 +1,24 @@
+---
+- name: SOPHOS FIREWALL ANSIBLE MODULE TESTING
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: MANAGE FIREWALL RULE GROUP
+      sophos.sophos_firewall.sfos_firewall_rulegroup:
+        username: "{{ username }}"
+        password: "{{ password }}"
+        hostname: "{{ inventory_hostname }}"
+        port: 4444
+        verify: false
+        name: TESTRULEGROUP1
+        description: Created by Ansible
+        policy_list:
+          - ANSIBLE DEMO
+        source_zones:
+          - LAN
+        dest_zones:
+          - WAN
+        policy_type: Any
+        state: present
+      delegate_to: localhost


### PR DESCRIPTION
- Add the sfos_firewall_rulegroup module to allow adding rules to a rule group and/or changing rule group settings. 
- requires sophosfirewall-python version v0.1.59 or greater. 
