### PR TITLE
Fix: sfos_syslog requiring unnecessary arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,52 @@
 
 **Topics**
 
-- <a href="#v1-4-3">v1\.4\.3</a>
-    - <a href="#bugfixes">Bugfixes</a>
-- <a href="#v1-4-2">v1\.4\.2</a>
+- <a href="#v1-4-4">v1\.4\.4</a>
     - <a href="#release-summary">Release Summary</a>
+    - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v1-4-3">v1\.4\.3</a>
     - <a href="#bugfixes-1">Bugfixes</a>
-- <a href="#v1-4-1">v1\.4\.1</a>
-    - <a href="#bugfixes-2">Bugfixes</a>
-- <a href="#v1-4-0">v1\.4\.0</a>
+- <a href="#v1-4-2">v1\.4\.2</a>
     - <a href="#release-summary-1">Release Summary</a>
+    - <a href="#bugfixes-2">Bugfixes</a>
+- <a href="#v1-4-1">v1\.4\.1</a>
+    - <a href="#bugfixes-3">Bugfixes</a>
+- <a href="#v1-4-0">v1\.4\.0</a>
+    - <a href="#release-summary-2">Release Summary</a>
     - <a href="#new-modules">New Modules</a>
 - <a href="#v1-3-0">v1\.3\.0</a>
-    - <a href="#release-summary-2">Release Summary</a>
+    - <a href="#release-summary-3">Release Summary</a>
     - <a href="#new-modules-1">New Modules</a>
 - <a href="#v1-2-1">v1\.2\.1</a>
-    - <a href="#release-summary-3">Release Summary</a>
-    - <a href="#bugfixes-3">Bugfixes</a>
-- <a href="#v1-2-0">v1\.2\.0</a>
     - <a href="#release-summary-4">Release Summary</a>
+    - <a href="#bugfixes-4">Bugfixes</a>
+- <a href="#v1-2-0">v1\.2\.0</a>
+    - <a href="#release-summary-5">Release Summary</a>
     - <a href="#new-modules-2">New Modules</a>
 - <a href="#v1-1-0">v1\.1\.0</a>
-    - <a href="#release-summary-5">Release Summary</a>
+    - <a href="#release-summary-6">Release Summary</a>
     - <a href="#new-modules-3">New Modules</a>
 - <a href="#v1-0-0">v1\.0\.0</a>
-    - <a href="#release-summary-6">Release Summary</a>
+    - <a href="#release-summary-7">Release Summary</a>
     - <a href="#new-modules-4">New Modules</a>
+
+<a id="v1-4-4"></a>
+## v1\.4\.4
+
+<a id="release-summary"></a>
+### Release Summary
+
+This is a bugfix release for the Sophos Firewall Ansible collection\.
+
+<a id="bugfixes"></a>
+### Bugfixes
+
+* Fixed an issue where the sfos\_syslog module required unneccessary arguments when updating logging settings\.
 
 <a id="v1-4-3"></a>
 ## v1\.4\.3
 
-<a id="bugfixes"></a>
+<a id="bugfixes-1"></a>
 ### Bugfixes
 
 * Fixed an issue where the sfos\_syslog module would fail to update log settings
@@ -39,12 +55,12 @@
 <a id="v1-4-2"></a>
 ## v1\.4\.2
 
-<a id="release-summary"></a>
+<a id="release-summary-1"></a>
 ### Release Summary
 
 Bugfix
 
-<a id="bugfixes-1"></a>
+<a id="bugfixes-2"></a>
 ### Bugfixes
 
 * Fixed issue with service\_acl\_exception crashing when no destination hosts are defined
@@ -52,7 +68,7 @@ Bugfix
 <a id="v1-4-1"></a>
 ## v1\.4\.1
 
-<a id="bugfixes-2"></a>
+<a id="bugfixes-3"></a>
 ### Bugfixes
 
 * Correct test files
@@ -60,7 +76,7 @@ Bugfix
 <a id="v1-4-0"></a>
 ## v1\.4\.0
 
-<a id="release-summary-1"></a>
+<a id="release-summary-2"></a>
 ### Release Summary
 
 This release introduces a new module for working with firewall rule groups\.
@@ -73,7 +89,7 @@ This release introduces a new module for working with firewall rule groups\.
 <a id="v1-3-0"></a>
 ## v1\.3\.0
 
-<a id="release-summary-2"></a>
+<a id="release-summary-3"></a>
 ### Release Summary
 
 This release adds modules for working with authentication servers
@@ -91,12 +107,12 @@ This release adds modules for working with authentication servers
 <a id="v1-2-1"></a>
 ## v1\.2\.1
 
-<a id="release-summary-3"></a>
+<a id="release-summary-4"></a>
 ### Release Summary
 
 Minor bug fixes
 
-<a id="bugfixes-3"></a>
+<a id="bugfixes-4"></a>
 ### Bugfixes
 
 * Allow use of \'any\' keyword for src/dst networks and services for sfos\_firewall\_rule module
@@ -105,7 +121,7 @@ Minor bug fixes
 <a id="v1-2-0"></a>
 ## v1\.2\.0
 
-<a id="release-summary-4"></a>
+<a id="release-summary-5"></a>
 ### Release Summary
 
 This release adds modules for working with IPS and Syslog settings
@@ -119,7 +135,7 @@ This release adds modules for working with IPS and Syslog settings
 <a id="v1-1-0"></a>
 ## v1\.1\.0
 
-<a id="release-summary-5"></a>
+<a id="release-summary-6"></a>
 ### Release Summary
 
 This release contains new modules for working with the SNMP agent and SNMPv3 users on Sophos Firewall
@@ -133,7 +149,7 @@ This release contains new modules for working with the SNMP agent and SNMPv3 use
 <a id="v1-0-0"></a>
 ## v1\.0\.0
 
-<a id="release-summary-6"></a>
+<a id="release-summary-7"></a>
 ### Release Summary
 
 This is the first proper release of the <code>sophos\.sophos\_firewall</code> collection\.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -161,3 +161,12 @@ releases:
     fragments:
     - 1.4.3.yaml
     release_date: '2025-02-18'
+  1.4.4:
+    changes:
+      bugfixes:
+      - Fixed an issue where the sfos_syslog module required unneccessary arguments
+        when updating logging settings.
+      release_summary: This is a bugfix release for the Sophos Firewall Ansible collection.
+    fragments:
+    - 1.4.4.yaml
+    release_date: '2025-02-19'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: sophos
 name: sophos_firewall
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.3
+version: 1.4.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/sfos_syslog.py
+++ b/plugins/modules/sfos_syslog.py
@@ -730,7 +730,6 @@ def update_syslog(fw_obj, exist_settings, module, result):
             if syslog_server["Name"] == module.params.get("name"):
                 exist_settings = syslog_server
 
-    syslog_format = "3" if module.params.get("format") == "Standard syslog" else "DeviceStandardFormat"
     log_settings = get_with_default(module.params, "log_settings", {})
 
     security_policy = get_with_default(log_settings,"security_policy", {})
@@ -747,14 +746,19 @@ def update_syslog(fw_obj, exist_settings, module, result):
     zeroday_protection = get_with_default(log_settings,"zeroday_protection", {})
     sdwan = get_with_default(log_settings,"sdwan", {})
 
+    if module.params.get("format"):
+        syslog_format = "3" if module.params.get("format") == "Standard syslog" else "DeviceStandardFormat"
+    else:
+        syslog_format = exist_settings["Format"]
+
     template_vars = {
         "name": module.params.get("name"),
-        "address": module.params.get("address", exist_settings["ServerAddress"]),
-        "udp_port": module.params.get("udp_port", exist_settings["Port"]),
-        "secure_connection": module.params.get("secure_connection", exist_settings["EnableSecureConnection"]),
-        "facility": module.params.get("facility", exist_settings["Facility"]),
-        "severity": module.params.get("severity", exist_settings["SeverityLevel"]),
-        "format": syslog_format if syslog_format else exist_settings["Format"],
+        "address": get_with_default(module.params,"address", exist_settings["ServerAddress"]),
+        "udp_port": get_with_default(module.params, "udp_port", exist_settings["Port"]),
+        "secure_connection": get_with_default(module.params, "secure_connection", exist_settings["EnableSecureConnection"]),
+        "facility": get_with_default(module.params, "facility", exist_settings["Facility"]),
+        "severity": get_with_default(module.params,"severity", exist_settings["SeverityLevel"]),
+        "format": syslog_format,
         "policy_rules": get_with_default(security_policy, "policy_rules", exist_settings["LogSettings"]["SecurityPolicy"]["PolicyRules"]),
         "invalid_traffic": get_with_default(security_policy, "invalid_traffic", exist_settings["LogSettings"]["SecurityPolicy"]["InvalidTraffic"]),
         "local_acls": get_with_default(security_policy, "local_acls", exist_settings["LogSettings"]["SecurityPolicy"]["LocalACLs"]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sophosfirewall-ansible"
-version = "1.4.3"
+version = "1.4.4"
 description = "Ansible modules for Sophos Firewall"
 authors = ["Matt Mullen <matt.mullen@sophos.com>"]
 license = "GNU GENERAL PUBLIC LICENSE"

--- a/tests/manual/sfos_syslog.yml
+++ b/tests/manual/sfos_syslog.yml
@@ -4,6 +4,18 @@
   gather_facts: false
 
   tasks:
+    - name: Query syslog server
+      sophos.sophos_firewall.sfos_syslog:
+        username: "{{ username }}"
+        password: "{{ password }}"
+        hostname: "{{ inventory_hostname }}"
+        port: 4444
+        verify: false
+        name: TestSyslog1
+        state: query
+      delegate_to: localhost
+      tags: query
+
     - name: Create syslog server, all logging enabled
       sophos.sophos_firewall.sfos_syslog:
         username: "{{ username }}"
@@ -11,7 +23,7 @@
         hostname: "{{ inventory_hostname }}"
         port: 4444
         verify: false
-        name: TestSyslog
+        name: TestSyslog1
         address: 10.10.1.100
         udp_port: 514
         secure_connection: Disable
@@ -21,82 +33,103 @@
         default_logging: Enable
         state: present
       delegate_to: localhost
+      tags: create
 
-    - name: Update syslog server with some logging disable
+    - name: Update syslog server, change UDP port
       sophos.sophos_firewall.sfos_syslog:
         username: "{{ username }}"
         password: "{{ password }}"
         hostname: "{{ inventory_hostname }}"
         port: 4444
         verify: false
-        name: TestSyslog
+        name: TestSyslog1
         address: 10.10.1.100
-        udp_port: 514
-        secure_connection: Disable
-        facility: DAEMON
-        severity: Emergency
-        format: Device standard
-        default_logging: Enable
-        log_settings:
-          security_policy:
-            bridge_acls: Enable
-            dos_attack: Enable
-            dropped_fragment: Enable
-            dropped_icmpredirect: Enable
-            dropped_sourceroute: Enable
-            heartbeat: Enable
-            icmp_errormessage: Enable
-            invalid_traffic: Enable
-            ipmacpair_filtering: Enable
-            ipspoof_prevention: Enable
-            local_acls: Enable
-            mac_filtering: Enable
-            policy_rules: Enable
-            protected_application_server: Enable
-            ssl_vpntunnel: Enable
-          system_health:
-            usage: Enable
-          web_server_protection:
-            waf_events: Enable
-          wireless:
-            access_points_ssid: Enable
-          zeroday_protection:
-            zeroday_protection_events: Enable
-          content_filtering:
-            application_filter: Enable
-            ssl_tls: Enable
-            web_content_policy: Enable
-            web_filter: Enable
-          atp:
-            atp_events: Enable
-          anti_spam:
-            imap: Enable
-            imaps: Enable
-            pop3: Enable
-            pops: Enable
-            smtps: Enable
-          anti_virus:
-            ftp: Enable
-            http: Enable
-            https: Enable
-            imap: Enable
-            imaps: Enable
-            pop3: Enable
-            pops: Enable
-            smtp: Enable
-            smtps: Enable
-          events:
-            admin: Enable
-            authentication: Enable
-            system: Enable
-          heartbeat:
-            endpoint_status: Enable
-          ips:
-            anomaly: Enable
-            signatures: Enable
-          sdwan:
-            profile: Enable
-            route: Enable
-            sla: Enable
+        udp_port: 515
         state: updated
       delegate_to: localhost
+      tags: update_udp
+
+    - name: Update syslog server, all logging disabled
+      sophos.sophos_firewall.sfos_syslog:
+        username: "{{ username }}"
+        password: "{{ password }}"
+        hostname: "{{ inventory_hostname }}"
+        port: 4444
+        verify: false
+        name: TestSyslog1
+        log_settings:
+          security_policy:
+            bridge_acls: Disable
+            dos_attack: Disable
+            dropped_fragment: Disable
+            dropped_icmpredirect: Disable
+            dropped_sourceroute: Disable
+            heartbeat: Disable
+            icmp_errormessage: Disable
+            invalid_traffic: Disable
+            ipmacpair_filtering: Disable
+            ipspoof_prevention: Disable
+            local_acls: Disable
+            mac_filtering: Disable
+            policy_rules: Disable
+            protected_application_server: Disable
+            ssl_vpntunnel: Disable
+          system_health:
+            usage: Disable
+          web_server_protection:
+            waf_events: Disable
+          wireless:
+            access_points_ssid: Disable
+          zeroday_protection:
+            zeroday_protection_events: Disable
+          content_filtering:
+            application_filter: Disable
+            ssl_tls: Disable
+            web_content_policy: Disable
+            web_filter: Disable
+          atp:
+            atp_events: Disable
+          anti_spam:
+            imap: Disable
+            imaps: Disable
+            pop3: Disable
+            pops: Disable
+            smtps: Disable
+          anti_virus:
+            ftp: Disable
+            http: Disable
+            https: Disable
+            imap: Disable
+            imaps: Disable
+            pop3: Disable
+            pops: Disable
+            smtp: Disable
+            smtps: Disable
+          events:
+            admin: Disable
+            authentication: Disable
+            system: Disable
+          heartbeat:
+            endpoint_status: Disable
+          ips:
+            anomaly: Disable
+            signatures: Disable
+          sdwan:
+            profile: Disable
+            route: Disable
+            sla: Disable
+        state: updated
+      delegate_to: localhost
+      tags: update_logging
+
+    - name: Remove syslog server
+      sophos.sophos_firewall.sfos_syslog:
+        username: "{{ username }}"
+        password: "{{ password }}"
+        hostname: "{{ inventory_hostname }}"
+        port: 4444
+        verify: false
+        name: TestSyslog1
+        state: absent
+      delegate_to: localhost
+      tags: remove


### PR DESCRIPTION
When using the sfos_syslog module and only needing to update settings under `log_settings`, the module was still requiring other top-level arguments `address`, `udp_port`, `facility`, and `severity` arguments to be present.  This was corrected such that if these arguments are omitted, the existing settings are used. 