### PR TITLE
Modules for working with Web policies

### DIFF
--- a/tests/integration/targets/sfos_firewall_rule/tasks/main.yml
+++ b/tests/integration/targets/sfos_firewall_rule/tasks/main.yml
@@ -43,6 +43,8 @@
   loop:
     - IGT_TESTRULE
     - IGT_TESTRULE_ANY
+    - IGT_TESTRULE_WEBFILTER
+    - IGT_TESTRULE_QOS
 
 - name: CREATE NETWORKS
   sophos.sophos_firewall.sfos_ip_host:
@@ -61,7 +63,26 @@
     - name: IGT_TESTNETWORK3
       ip_address: 3.3.3.0
       mask: 255.255.255.0
-    
+
+- name: CREATE WEB FILTER POLICY
+  sfos_web_policy:
+    name: "IGT_TEST_POLICY"
+    default_action: "Allow"
+    description: "Basic test policy created by Ansible integration testing"
+    state: present
+
+- name: CREATE QOS POLICY
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: IGT_TEST_QOS_POLICY
+    policy_type: "Strict"
+    implementation_on: "Total"
+    priority: "BusinessCritical"
+    policy_based_on: "Firewall"
+    bandwidth_usage_type: "Shared"
+    total_bandwidth: 1000
+    description: "Test policy for integration testing"
+    state: present
+
 - name: CREATE FIREWALL RULE
   sophos.sophos_firewall.sfos_firewall_rule:
     name: IGT_TESTRULE
@@ -139,6 +160,89 @@
       - "'SourceNetworks' not in query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']"
       - "'DestinationNetworks' not in query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']"
       - "'Services' not in query_rule_any['api_response']['Response']['FirewallRule']['NetworkPolicy']"
+
+- name: CREATE FIREWALL RULE WITH WEB FILTER
+  sophos.sophos_firewall.sfos_firewall_rule:
+    name: IGT_TESTRULE_WEBFILTER
+    position: bottom
+    status: enable
+    src_networks:
+      - IGT_TESTNETWORK1
+    dst_networks:
+      - IGT_TESTNETWORK2
+    service_list:
+      - HTTPS
+    web_filter: IGT_TEST_POLICY
+    action: accept
+    state: present
+  register: create_rule
+
+- name: ASSERTION CHECK FOR CREATE FIREWALL RULE WITH WEB FILTER
+  assert:
+    that: 
+      - create_rule is changed
+      - create_rule['api_response']['Response']['FirewallRule']['Status']['@code'] == "200"
+      - create_rule['api_response']['Response']['FirewallRule']['Status']['#text'] == "Configuration applied successfully."
+
+- name: QUERY FIREWALL RULE WITH WEB FILTER
+  sophos.sophos_firewall.sfos_firewall_rule:
+    name: IGT_TESTRULE_WEBFILTER
+    state: query
+  register: query_rule
+
+- name: ASSERTION CHECK FOR QUERY FIREWALL RULE WITH WEB FILTER
+  assert:
+    that: 
+      - query_rule is not changed
+      - query_rule['api_response']['Response']['FirewallRule']['Name'] == "IGT_TESTRULE_WEBFILTER"
+      - query_rule['api_response']['Response']['FirewallRule']['Status'] == "Enable"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['Action'] == "Accept"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['SourceNetworks']['Network'] == "IGT_TESTNETWORK1"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['DestinationNetworks']['Network'] == "IGT_TESTNETWORK2"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['Services']['Service'] == "HTTPS"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['WebFilter'] == "IGT_TEST_POLICY"
+
+- name: CREATE FIREWALL RULE WITH QOS POLICY
+  sophos.sophos_firewall.sfos_firewall_rule:
+    name: IGT_TESTRULE_QOS
+    position: bottom
+    status: enable
+    src_networks:
+      - IGT_TESTNETWORK1
+    dst_networks:
+      - IGT_TESTNETWORK2
+    service_list:
+      - HTTPS
+    qos_policy: IGT_TEST_QOS_POLICY
+    action: accept
+    state: present
+  register: create_rule
+
+- name: ASSERTION CHECK FOR CREATE FIREWALL RULE WITH QOS POLICY
+  assert:
+    that: 
+      - create_rule is changed
+      - create_rule['api_response']['Response']['FirewallRule']['Status']['@code'] == "200"
+      - create_rule['api_response']['Response']['FirewallRule']['Status']['#text'] == "Configuration applied successfully."
+
+- name: QUERY FIREWALL RULE WITH QOS POLICY
+  sophos.sophos_firewall.sfos_firewall_rule:
+    name: IGT_TESTRULE_QOS
+    state: query
+  register: query_rule
+
+- name: ASSERTION CHECK FOR QUERY FIREWALL RULE WITH QOS POLICY
+  assert:
+    that: 
+      - query_rule is not changed
+      - query_rule['api_response']['Response']['FirewallRule']['Name'] == "IGT_TESTRULE_QOS"
+      - query_rule['api_response']['Response']['FirewallRule']['Status'] == "Enable"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['Action'] == "Accept"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['SourceNetworks']['Network'] == "IGT_TESTNETWORK1"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['DestinationNetworks']['Network'] == "IGT_TESTNETWORK2"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['Services']['Service'] == "HTTPS"
+      - query_rule['api_response']['Response']['FirewallRule']['NetworkPolicy']['TrafficShappingPolicy'] == "IGT_TEST_QOS_POLICY"
+
 
 
 - name: CREATE EXISTING FIREWALL RULE
@@ -240,6 +344,16 @@
     state: absent
   register: remove_rule
 
+- name: REMOVE IGT_TESTRULE_WEBFILTER
+  sophos.sophos_firewall.sfos_firewall_rule:
+    name: IGT_TESTRULE_WEBFILTER
+    state: absent
+
+- name: REMOVE IGT_TESTRULE_QOS
+  sophos.sophos_firewall.sfos_firewall_rule:
+    name: IGT_TESTRULE_QOS
+    state: absent
+
 - name: REMOVE TEST NETWORKS
   sophos.sophos_firewall.sfos_ip_host:
     name: "{{ item.name }}"
@@ -257,3 +371,13 @@
     - name: IGT_TESTNETWORK3
       ip_address: 3.3.3.0
       mask: 255.255.255.0
+
+- name: REMOVE WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT_TEST_POLICY
+    state: absent
+
+- name: REMOVE QOS POLICY
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: IGT_TEST_QOS_POLICY
+    state: absent

--- a/tests/integration/targets/sfos_qos_policy/aliases
+++ b/tests/integration/targets/sfos_qos_policy/aliases
@@ -1,0 +1,1 @@
+gather_facts/no

--- a/tests/integration/targets/sfos_qos_policy/tasks/main.yml
+++ b/tests/integration/targets/sfos_qos_policy/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Import sfos_qos_policy create tests
+  import_tasks: test_sfos_qos_policy_create.yml
+
+- name: Import sfos_qos_policy query tests
+  import_tasks: test_sfos_qos_policy_query.yml
+
+- name: Import sfos_qos_policy update tests
+  import_tasks: test_sfos_qos_policy_update.yml
+
+- name: Import sfos_qos_policy remove tests
+  import_tasks: test_sfos_qos_policy_remove.yml
+
+- name: Import sfos_qos_policy advanced tests
+  import_tasks: test_sfos_qos_policy_advanced.yml

--- a/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_advanced.yml
+++ b/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_advanced.yml
@@ -1,0 +1,161 @@
+---
+# Test Advanced QoS Policy Features
+- name: Pre-test cleanup - Remove advanced test QoS policies
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "Test QoS Schedule Based - Single Rule"
+    - "Test QoS Schedule Based"
+    - "Test QoS WebCategory"
+    - "Test QoS BestEffort"
+  ignore_errors: true
+
+- name: Create QoS Policy with single Schedule-based Rule
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Schedule Based - Single Rule"
+    policy_type: "Strict"
+    implementation_on: "Total"
+    priority: "Normal3"
+    policy_based_on: "Firewall"
+    bandwidth_usage_type: "Shared"
+    total_bandwidth: 2000
+    description: "Policy with schedule-based bandwidth rules"
+    schedule_based_rules:
+      - detail_id: "BusinessHours"
+        policy_type: "Strict"
+        total_bandwidth: 1500
+        schedule: "AllTime"
+    state: present
+  register: result
+
+- name: Assert Schedule-based QoS Policy with single rule created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Schedule-based QoS Policy creation failed"
+    success_msg: "Schedule-based QoS Policy with single rule created successfully"
+
+- name: Create QoS Policy with Schedule-based Rules
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Schedule Based"
+    policy_type: "Strict"
+    implementation_on: "Total"
+    priority: "Normal3"
+    policy_based_on: "Firewall"
+    bandwidth_usage_type: "Shared"
+    total_bandwidth: 2000
+    description: "Policy with schedule-based bandwidth rules"
+    schedule_based_rules:
+      - detail_id: "BusinessHours"
+        policy_type: "Strict"
+        total_bandwidth: 1500
+        schedule: "AllTime"
+      - detail_id: "OffHours"
+        policy_type: "Committed"
+        guaranteed_bandwidth: 500
+        burstable_bandwidth: 1000
+        schedule: "AllTime"
+    state: present
+  register: result
+
+- name: Assert Schedule-based QoS Policy created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Schedule-based QoS Policy creation failed"
+    success_msg: "Schedule-based QoS Policy created successfully"
+
+- name: Create QoS Policy for WebCategory
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS WebCategory"
+    policy_type: "Committed"
+    implementation_on: "Individual"
+    priority: "Normal4"
+    policy_based_on: "WebCategory"
+    bandwidth_usage_type: "Individual"
+    guaranteed_upload_bandwidth: 200
+    burstable_upload_bandwidth: 500
+    guaranteed_download_bandwidth: 500
+    burstable_download_bandwidth: 1000
+    description: "QoS policy for web categories"
+    state: present
+  register: result
+
+- name: Assert WebCategory QoS Policy created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "WebCategory QoS Policy creation failed"
+    success_msg: "WebCategory QoS Policy created successfully"
+
+- name: Create QoS Policy with BestEffort priority
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS BestEffort"
+    policy_type: "Strict"
+    implementation_on: "Individual"
+    priority: "BestEffort"
+    policy_based_on: "User"
+    bandwidth_usage_type: "Individual"
+    upload_bandwidth: 100
+    download_bandwidth: 200
+    description: "Best effort QoS policy"
+    state: present
+  register: result
+
+- name: Assert BestEffort QoS Policy created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "BestEffort QoS Policy creation failed"
+    success_msg: "BestEffort QoS Policy created successfully"
+
+- name: Test parameter validation - Invalid bandwidth range
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test Invalid Bandwidth"
+    priority: "Normal2"
+    total_bandwidth: 1
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Assert invalid bandwidth validation
+  assert:
+    that:
+      - result.failed == true
+      - "'must be between 2 and 10240000' in result.msg"
+    fail_msg: "Bandwidth validation should fail for values outside range"
+    success_msg: "Bandwidth validation correctly failed"
+
+- name: Test parameter validation - Burstable less than guaranteed
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test Invalid Burstable"
+    priority: "Normal2"
+    guaranteed_bandwidth: 1000
+    burstable_bandwidth: 500
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Assert burstable bandwidth validation
+  assert:
+    that:
+      - result.failed == true
+      - "'Burstable bandwidth must be greater than guaranteed bandwidth' in result.msg"
+    fail_msg: "Burstable bandwidth validation should fail"
+    success_msg: "Burstable bandwidth validation correctly failed"
+
+- name: Clean up advanced test QoS policies
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "Test QoS Schedule Based - Single Rule"
+    - "Test QoS Schedule Based"
+    - "Test QoS WebCategory"
+    - "Test QoS BestEffort"
+  ignore_errors: true

--- a/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_create.yml
+++ b/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_create.yml
@@ -1,0 +1,95 @@
+---
+# Test QoS Policy Creation
+- name: Pre-test cleanup - Remove test QoS policies
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "Test QoS Strict Total"
+    - "Test QoS Committed Individual" 
+    - "Test QoS Business Critical"
+  ignore_errors: true
+
+- name: Create QoS Policy - Strict Total type
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    policy_type: "Strict"
+    implementation_on: "Total"
+    priority: "BusinessCritical"
+    policy_based_on: "User"
+    bandwidth_usage_type: "Shared"
+    total_bandwidth: 1000
+    description: "Test strict policy with total bandwidth control"
+    state: present
+  register: result
+
+- name: Assert QoS Policy created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "QoS Policy creation failed"
+    success_msg: "QoS Policy created successfully"
+
+- name: Create QoS Policy - Committed Individual type
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Committed Individual"
+    policy_type: "Committed"
+    implementation_on: "Individual"
+    priority: "Normal2"
+    policy_based_on: "Application"
+    bandwidth_usage_type: "Individual"
+    guaranteed_upload_bandwidth: 500
+    burstable_upload_bandwidth: 1000
+    guaranteed_download_bandwidth: 1000
+    burstable_download_bandwidth: 2000
+    description: "Test committed policy with individual bandwidth limits"
+    state: present
+  register: result
+
+- name: Assert QoS Policy created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Committed QoS Policy creation failed"
+    success_msg: "Committed QoS Policy created successfully"
+
+- name: Create QoS Policy - RealTime priority
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Business Critical"
+    policy_type: "Strict"
+    implementation_on: "Individual"
+    priority: "RealTime"
+    policy_based_on: "Firewall"
+    bandwidth_usage_type: "Individual"
+    upload_bandwidth: 2000
+    download_bandwidth: 4000
+    description: "Test policy with RealTime priority"
+    state: present
+  register: result
+
+- name: Assert RealTime QoS Policy created successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "RealTime QoS Policy creation failed"
+    success_msg: "RealTime QoS Policy created successfully"
+
+- name: Attempt to create duplicate QoS Policy
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    policy_type: "Strict"
+    implementation_on: "Total"
+    priority: "BusinessCritical"
+    total_bandwidth: 2000
+    state: present
+  register: result
+
+- name: Assert duplicate QoS Policy not changed
+  assert:
+    that:
+      - result.changed == false
+    fail_msg: "Duplicate QoS Policy should not be changed"
+    success_msg: "Duplicate QoS Policy correctly not changed"

--- a/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_query.yml
+++ b/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_query.yml
@@ -1,0 +1,46 @@
+---
+# Test QoS Policy Queries
+- name: Query existing QoS Policy - Strict Total
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    state: query
+  register: result
+
+- name: Assert QoS Policy query successful
+  assert:
+    that:
+      - result.api_response.Response.QoSPolicy.Name == "Test QoS Strict Total"
+      - result.api_response.Response.QoSPolicy.PolicyType == "Strict"
+      - result.api_response.Response.QoSPolicy.ImplementationOn == "Total"
+      - result.api_response.Response.QoSPolicy.Priority == "BusinessCritical"
+    fail_msg: "QoS Policy query failed or returned incorrect data"
+    success_msg: "QoS Policy query successful"
+
+- name: Query existing QoS Policy - Committed Individual
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Committed Individual"
+    state: query
+  register: result
+
+- name: Assert Committed QoS Policy query successful
+  assert:
+    that:
+      - result.api_response.Response.QoSPolicy.Name == "Test QoS Committed Individual"
+      - result.api_response.Response.QoSPolicy.PolicyType == "Committed"
+      - result.api_response.Response.QoSPolicy.ImplementationOn == "Individual"
+      - result.api_response.Response.QoSPolicy.Priority == "Normal2"
+    fail_msg: "Committed QoS Policy query failed or returned incorrect data"
+    success_msg: "Committed QoS Policy query successful"
+
+- name: Query non-existent QoS Policy
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "NonExistent QoS Policy"
+    state: query
+  register: result
+
+- name: Assert non-existent QoS Policy query returns empty
+  assert:
+    that:
+      - result.api_response.Response.QoSPolicy.Name is not defined or result.api_response.Response.QoSPolicy.Name == ""
+    fail_msg: "Non-existent QoS Policy query should return empty result"
+    success_msg: "Non-existent QoS Policy query correctly returned empty"

--- a/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_remove.yml
+++ b/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_remove.yml
@@ -1,0 +1,69 @@
+---
+# Test QoS Policy Removal
+- name: Remove QoS Policy - Strict Total
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    state: absent
+  register: result
+
+- name: Assert QoS Policy removed successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "QoS Policy removal failed"
+    success_msg: "QoS Policy removed successfully"
+
+- name: Verify QoS Policy removal
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    state: query
+  register: result
+
+- name: Assert QoS Policy no longer exists
+  assert:
+    that:
+      - result.api_response.Response.QoSPolicy.Name is not defined or result.api_response.Response.QoSPolicy.Name == ""
+    fail_msg: "QoS Policy should not exist after removal"
+    success_msg: "QoS Policy correctly removed"
+
+- name: Remove QoS Policy - Committed Individual
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Committed Individual"
+    state: absent
+  register: result
+
+- name: Assert Committed QoS Policy removed successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Committed QoS Policy removal failed"
+    success_msg: "Committed QoS Policy removed successfully"
+
+- name: Remove QoS Policy - Business Critical
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Business Critical"
+    state: absent
+  register: result
+
+- name: Assert Business Critical QoS Policy removed successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Business Critical QoS Policy removal failed"
+    success_msg: "Business Critical QoS Policy removed successfully"
+
+- name: Remove non-existent QoS Policy
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "NonExistent QoS Policy"
+    state: absent
+  register: result
+
+- name: Assert non-existent QoS Policy removal is idempotent
+  assert:
+    that:
+      - result.changed == false
+    fail_msg: "Non-existent QoS Policy removal should be idempotent"
+    success_msg: "Non-existent QoS Policy removal correctly idempotent"

--- a/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_update.yml
+++ b/tests/integration/targets/sfos_qos_policy/tasks/test_sfos_qos_policy_update.yml
@@ -1,0 +1,82 @@
+---
+# Test QoS Policy Updates
+- name: Update QoS Policy - Change total bandwidth
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    total_bandwidth: 1500
+    description: "Updated strict policy with increased bandwidth"
+    state: updated
+  register: result
+
+- name: Assert QoS Policy updated successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "QoS Policy update failed"
+    success_msg: "QoS Policy updated successfully"
+
+- name: Verify QoS Policy update
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Strict Total"
+    state: query
+  register: result
+
+- name: Assert QoS Policy changes applied
+  assert:
+    that:
+      - result.api_response.Response.QoSPolicy.TotalBandwidth == "1500"
+      - result.api_response.Response.QoSPolicy.Description == "Updated strict policy with increased bandwidth"
+    fail_msg: "QoS Policy changes were not applied correctly"
+    success_msg: "QoS Policy changes applied successfully"
+
+- name: Update QoS Policy - Change bandwidth limits for Individual type
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Committed Individual"
+    guaranteed_upload_bandwidth: 750
+    burstable_upload_bandwidth: 1500
+    guaranteed_download_bandwidth: 1500
+    burstable_download_bandwidth: 3000
+    description: "Updated committed policy with increased bandwidth limits"
+    state: updated
+  register: result
+
+- name: Assert Individual QoS Policy updated successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Individual QoS Policy update failed"
+    success_msg: "Individual QoS Policy updated successfully"
+
+- name: Update QoS Policy - Change priority level
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "Test QoS Business Critical"
+    priority: "Normal3"
+    description: "Updated policy with changed priority"
+    state: updated
+  register: result
+
+- name: Assert Priority QoS Policy updated successfully
+  assert:
+    that:
+      - result.changed == true
+      - result.api_response.Response.QoSPolicy.Status['@code'] in ['200', '217'] or "successfully" in result.api_response.Response.QoSPolicy.Status['#text']
+    fail_msg: "Priority QoS Policy update failed"
+    success_msg: "Priority QoS Policy updated successfully"
+
+- name: Update non-existent QoS Policy
+  sophos.sophos_firewall.sfos_qos_policy:
+    name: "NonExistent QoS Policy"
+    total_bandwidth: 2000
+    state: updated
+  register: result
+  ignore_errors: true
+
+- name: Assert non-existent QoS Policy update fails
+  assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+    fail_msg: "Non-existent QoS Policy update should fail"
+    success_msg: "Non-existent QoS Policy update correctly failed"

--- a/tests/integration/targets/sfos_web_category/aliases
+++ b/tests/integration/targets/sfos_web_category/aliases
@@ -1,0 +1,1 @@
+gather_facts/no

--- a/tests/integration/targets/sfos_web_category/tasks/main.yml
+++ b/tests/integration/targets/sfos_web_category/tasks/main.yml
@@ -1,0 +1,277 @@
+# Copyright 2024 Sophos Ltd.  All rights reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+- name: CHECK REQUIRED VARS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure these variables are set in tests/integration/integration_config.yml: 
+      - ansible_user
+      - ansible_host
+      - ansible_password
+      - ansible_connection
+      - ansible_httpapi_validate_certs
+      - ansible_httpapi_port
+      - ansible_network_os
+      
+  when: ansible_user is not defined or
+        ansible_host is not defined or
+        ansible_password is not defined or
+        ansible_connection is not defined or
+        ansible_httpapi_validate_certs is not defined or
+        ansible_httpapi_port is not defined or
+        ansible_network_os is not defined
+
+- name: CHECK CONNECTION
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_connection is set to ansible.netcommon.httpapi in tests/integration/integration_config.yml
+      
+  when: ansible_connection != "ansible.netcommon.httpapi"
+
+- name: CHECK NETWORK_OS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_network_os is set to sophos.sophos_firewall.sfos in tests/integration/integration_config.yml
+      
+  when: ansible_network_os != "sophos.sophos_firewall.sfos"
+
+# PRE-TEST CLEANUP - Remove any objects that might be left from previous test runs
+- name: CLEANUP - REMOVE WEB CATEGORY LOCAL
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-LOCAL
+    state: absent
+  register: cleanup_local
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB CATEGORY EXTERNAL
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-EXTERNAL
+    state: absent
+  register: cleanup_external
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB CATEGORY WITH MESSAGE
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-MESSAGE
+    state: absent
+  register: cleanup_message
+  ignore_errors: true
+
+- name: PAUSE AFTER CLEANUP
+  pause:
+    seconds: 3
+  when: cleanup_local.changed or cleanup_external.changed or cleanup_message.changed
+
+- name: CREATE WEB CATEGORY WITH LOCAL CONFIGURATION
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-LOCAL
+    classification: Productive
+    description: "Test web category for integration testing"
+    configurecategory: Local
+    domain_url:
+      - example.com
+      - test.org
+    keyword:
+      - productivity
+      - business
+    state: present
+  register: web_category_add_local
+
+- name: ASSERTION CHECK FOR CREATE WEB CATEGORY LOCAL
+  assert:
+    that: 
+      - web_category_add_local is changed
+      - web_category_add_local['api_response']['Response']['WebFilterCategory']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in web_category_add_local['api_response']['Response']['WebFilterCategory']['Status']['#text']"
+
+- name: QUERY WEB CATEGORY LOCAL
+  sophos.sophos_firewall.sfos_web_category:
+    state: query
+    name: IGT-TEST-CATEGORY-LOCAL
+  register: query_web_category_local
+
+- name: ASSERTION CHECK FOR QUERY WEB CATEGORY LOCAL
+  assert:
+    that: 
+      - query_web_category_local is not changed
+      - query_web_category_local['api_response']['Response']['WebFilterCategory']['Name'] == 'IGT-TEST-CATEGORY-LOCAL'
+      - query_web_category_local['api_response']['Response']['WebFilterCategory']['Classification'] == 'Productive'
+      - query_web_category_local['api_response']['Response']['WebFilterCategory']['QoSPolicy'] == 'None'
+      - query_web_category_local['api_response']['Response']['WebFilterCategory']['ConfigureCategory'] == 'Local'
+      - query_web_category_local['api_response']['Response']['WebFilterCategory']['Description'] == 'Test web category for integration testing'
+
+- name: CREATE WEB CATEGORY WITH EXTERNAL CONFIGURATION
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-EXTERNAL
+    classification: Unproductive
+    qospolicy: None
+    description: "Test external web category"
+    configurecategory: External
+    domain_url:
+      - http://custom.com
+      - ftp://custom1.com
+    state: present
+  register: web_category_add_external
+  vars:
+    ansible_command_timeout: 90
+
+- name: ASSERTION CHECK FOR CREATE WEB CATEGORY EXTERNAL
+  assert:
+    that: 
+      - web_category_add_external is changed
+      - (web_category_add_external['api_response']['Response']['WebFilterCategory']['Status']['@code'] == '200' and 
+         'Configuration applied successfully' in web_category_add_external['api_response']['Response']['WebFilterCategory']['Status']['#text']) or
+        (web_category_add_external['api_response']['Response']['WebFilterCategory']['Status']['@code'] == '217' and 
+         'Unable to get status message' in web_category_add_external['api_response']['Response']['WebFilterCategory']['Status']['#text'])
+
+- name: QUERY WEB CATEGORY EXTERNAL
+  sophos.sophos_firewall.sfos_web_category:
+    state: query
+    name: IGT-TEST-CATEGORY-EXTERNAL
+  register: query_web_category_external
+
+- name: ASSERTION CHECK FOR QUERY WEB CATEGORY EXTERNAL
+  assert:
+    that: 
+      - query_web_category_external is not changed
+      - query_web_category_external['api_response']['Response']['WebFilterCategory']['Name'] == 'IGT-TEST-CATEGORY-EXTERNAL'
+      - query_web_category_external['api_response']['Response']['WebFilterCategory']['Classification'] == 'Unproductive'
+      - query_web_category_external['api_response']['Response']['WebFilterCategory']['ConfigureCategory'] == 'External'
+
+- name: UPDATE WEB CATEGORY LOCAL
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-LOCAL
+    classification: Acceptable
+    description: "Updated test web category description"
+    domain_url:
+      - example.com
+      - test.org
+      - newdomain.com
+    keyword:
+      - productivity
+      - business
+      - efficiency
+    state: updated
+  register: update_web_category_local
+
+
+- name: ASSERTION CHECK FOR UPDATE WEB CATEGORY LOCAL
+  assert:
+    that: 
+      - update_web_category_local is changed
+      - update_web_category_local['api_response']['Response']['WebFilterCategory']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_web_category_local['api_response']['Response']['WebFilterCategory']['Status']['#text']"
+
+- name: QUERY UPDATED WEB CATEGORY LOCAL
+  sophos.sophos_firewall.sfos_web_category:
+    state: query
+    name: IGT-TEST-CATEGORY-LOCAL
+  register: query_updated_web_category
+
+
+- name: ASSERTION CHECK FOR QUERY UPDATED WEB CATEGORY
+  assert:
+    that: 
+      - query_updated_web_category is not changed
+      - query_updated_web_category['api_response']['Response']['WebFilterCategory']['Name'] == 'IGT-TEST-CATEGORY-LOCAL'
+      - query_updated_web_category['api_response']['Response']['WebFilterCategory']['Classification'] == 'Acceptable'
+      - query_updated_web_category['api_response']['Response']['WebFilterCategory']['Description'] == 'Updated test web category description'
+
+- name: UPDATE WEB CATEGORY LOCAL NO CHANGE
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-LOCAL
+    classification: Acceptable
+    description: "Updated test web category description"
+    state: updated
+  register: update_web_category_nochange
+
+- name: ASSERTION CHECK FOR UPDATE WEB CATEGORY LOCAL NO CHANGE
+  assert:
+    that: 
+      - update_web_category_nochange is not changed
+
+- name: CREATE WEB CATEGORY WITH CUSTOM DENIED MESSAGE
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-MESSAGE
+    classification: Objectionable
+    qospolicy: None
+    configurecategory: Local
+    defaultdeniedmessage: "<h1>Access Denied</h1><p>This content is blocked by company policy.</p>"
+    state: present
+  register: web_category_add_message
+
+- name: ASSERTION CHECK FOR CREATE WEB CATEGORY WITH MESSAGE
+  assert:
+    that: 
+      - web_category_add_message is changed
+      - web_category_add_message['api_response']['Response']['WebFilterCategory']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in web_category_add_message['api_response']['Response']['WebFilterCategory']['Status']['#text']"
+
+- name: QUERY WEB CATEGORY WITH MESSAGE
+  sophos.sophos_firewall.sfos_web_category:
+    state: query
+    name: IGT-TEST-CATEGORY-MESSAGE
+  register: query_web_category_message
+
+- name: ASSERTION CHECK FOR QUERY WEB CATEGORY WITH MESSAGE
+  assert:
+    that: 
+      - query_web_category_message is not changed
+      - query_web_category_message['api_response']['Response']['WebFilterCategory']['Name'] == 'IGT-TEST-CATEGORY-MESSAGE'
+      - query_web_category_message['api_response']['Response']['WebFilterCategory']['OverrideDefaultDeniedMessage'] == 'Enable'
+      - "'Access Denied' in query_web_category_message['api_response']['Response']['WebFilterCategory']['DefaultDeniedMessage']"
+
+- name: REMOVE WEB CATEGORY LOCAL
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-LOCAL
+    state: absent
+  register: remove_web_category_local
+
+- name: ASSERTION CHECK FOR REMOVE WEB CATEGORY LOCAL
+  assert:
+    that: 
+      - remove_web_category_local is changed
+      - remove_web_category_local['api_response']['Response']['WebFilterCategory']['Status']['@code'] == "200"
+      - remove_web_category_local['api_response']['Response']['WebFilterCategory']['Status']['#text'] == "Configuration applied successfully."
+
+- name: REMOVE WEB CATEGORY EXTERNAL
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-EXTERNAL
+    state: absent
+  register: remove_web_category_external
+
+
+- name: ASSERTION CHECK FOR REMOVE WEB CATEGORY EXTERNAL
+  assert:
+    that: 
+      - remove_web_category_external is changed
+      - (remove_web_category_external['api_response']['Response']['WebFilterCategory']['Status']['@code'] == "200" and
+         remove_web_category_external['api_response']['Response']['WebFilterCategory']['Status']['#text'] == "Configuration applied successfully.") or
+        (remove_web_category_external['api_response']['Response']['WebFilterCategory']['Status']['@code'] == "217" and
+         "Unable to get status message" in remove_web_category_external['api_response']['Response']['WebFilterCategory']['Status']['#text'])
+
+- name: REMOVE WEB CATEGORY WITH MESSAGE
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-MESSAGE
+    state: absent
+  register: remove_web_category_message
+
+- name: ASSERTION CHECK FOR REMOVE WEB CATEGORY WITH MESSAGE
+  assert:
+    that: 
+      - remove_web_category_message is changed
+      - remove_web_category_message['api_response']['Response']['WebFilterCategory']['Status']['@code'] == "200"
+      - remove_web_category_message['api_response']['Response']['WebFilterCategory']['Status']['#text'] == "Configuration applied successfully."
+
+- name: REMOVE NONEXISTING WEB CATEGORY
+  sophos.sophos_firewall.sfos_web_category:
+    name: IGT-TEST-CATEGORY-NONEXISTENT
+    state: absent
+  register: remove_web_category_nonexistent
+
+- name: ASSERTION CHECK FOR REMOVE NONEXISTING WEB CATEGORY
+  assert:
+    that: 
+      - remove_web_category_nonexistent is not changed
+      - remove_web_category_nonexistent['api_response'] == "No. of records Zero."

--- a/tests/integration/targets/sfos_web_filetype/aliases
+++ b/tests/integration/targets/sfos_web_filetype/aliases
@@ -1,0 +1,1 @@
+gather_facts/no

--- a/tests/integration/targets/sfos_web_filetype/tasks/main.yml
+++ b/tests/integration/targets/sfos_web_filetype/tasks/main.yml
@@ -1,0 +1,301 @@
+# Copyright 2024 Sophos Ltd.  All rights reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+- name: CHECK REQUIRED VARS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure these variables are set in tests/integration/integration_config.yml: 
+      - ansible_user
+      - ansible_host
+      - ansible_password
+      - ansible_connection
+      - ansible_httpapi_validate_certs
+      - ansible_httpapi_port
+      - ansible_network_os
+      
+  when: ansible_user is not defined or
+        ansible_host is not defined or
+        ansible_password is not defined or
+        ansible_connection is not defined or
+        ansible_httpapi_validate_certs is not defined or
+        ansible_httpapi_port is not defined or
+        ansible_network_os is not defined
+
+- name: CHECK CONNECTION
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_connection is set to ansible.netcommon.httpapi in tests/integration/integration_config.yml
+      
+  when: ansible_connection != "ansible.netcommon.httpapi"
+
+- name: CHECK NETWORK_OS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_network_os is set to sophos.sophos_firewall.sfos in tests/integration/integration_config.yml
+      
+  when: ansible_network_os != "sophos.sophos_firewall.sfos"
+
+# PRE-TEST CLEANUP - Remove any objects that might be left from previous test runs
+- name: CLEANUP - REMOVE WEB FILE TYPE BASIC
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-BASIC
+    state: absent
+  register: cleanup_basic
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB FILE TYPE ADVANCED
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-ADVANCED
+    state: absent
+  register: cleanup_advanced
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB FILE TYPE DESCRIPTION
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-DESC
+    state: absent
+  register: cleanup_description
+  ignore_errors: true
+
+- name: PAUSE AFTER CLEANUP
+  pause:
+    seconds: 3
+  when: cleanup_basic.changed or cleanup_advanced.changed or cleanup_description.changed
+
+- name: CREATE WEB FILE TYPE WITH BASIC CONFIGURATION
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-BASIC
+    description: "Basic file type for integration testing"
+    file_extension:
+      - pdf
+      - doc
+      - txt
+    state: present
+  register: web_filetype_add_basic
+
+- name: ASSERTION CHECK FOR CREATE WEB FILE TYPE BASIC
+  assert:
+    that: 
+      - web_filetype_add_basic is changed
+      - web_filetype_add_basic['api_response']['Response']['FileType']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in web_filetype_add_basic['api_response']['Response']['FileType']['Status']['#text']"
+
+- name: QUERY WEB FILE TYPE BASIC
+  sophos.sophos_firewall.sfos_web_filetype:
+    state: query
+    name: IGT-TEST-FILETYPE-BASIC
+  register: query_web_filetype_basic
+
+- name: ASSERTION CHECK FOR QUERY WEB FILE TYPE BASIC
+  assert:
+    that: 
+      - query_web_filetype_basic is not changed
+      - query_web_filetype_basic['api_response']['Response']['FileType']['Name'] == 'IGT-TEST-FILETYPE-BASIC'
+      - query_web_filetype_basic['api_response']['Response']['FileType']['Description'] == 'Basic file type for integration testing'
+      - "'pdf' in query_web_filetype_basic['api_response']['Response']['FileType']['FileExtensionList']['FileExtension']"
+
+- name: CREATE WEB FILE TYPE WITH ADVANCED CONFIGURATION
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-ADVANCED
+    description: "Advanced file type with extensions and MIME headers"
+    file_extension:
+      - jpg
+      - png
+      - gif
+    mime_header:
+      - image/jpeg
+      - image/png
+      - image/gif
+    state: present
+  register: web_filetype_add_advanced
+
+- name: ASSERTION CHECK FOR CREATE WEB FILE TYPE ADVANCED
+  assert:
+    that: 
+      - web_filetype_add_advanced is changed
+      - web_filetype_add_advanced['api_response']['Response']['FileType']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in web_filetype_add_advanced['api_response']['Response']['FileType']['Status']['#text']"
+
+- name: QUERY WEB FILE TYPE ADVANCED
+  sophos.sophos_firewall.sfos_web_filetype:
+    state: query
+    name: IGT-TEST-FILETYPE-ADVANCED
+  register: query_web_filetype_advanced
+
+- name: ASSERTION CHECK FOR QUERY WEB FILE TYPE ADVANCED
+  assert:
+    that: 
+      - query_web_filetype_advanced is not changed
+      - query_web_filetype_advanced['api_response']['Response']['FileType']['Name'] == 'IGT-TEST-FILETYPE-ADVANCED'
+      - query_web_filetype_advanced['api_response']['Response']['FileType']['Description'] == 'Advanced file type with extensions and MIME headers'
+      - "'jpg' in query_web_filetype_advanced['api_response']['Response']['FileType']['FileExtensionList']['FileExtension']"
+      - "'image/jpeg' in query_web_filetype_advanced['api_response']['Response']['FileType']['MIMEHeaderList']['MIMEHeader']"
+
+- name: UPDATE WEB FILE TYPE BASIC
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-BASIC
+    description: "Updated basic file type description"
+    file_extension:
+      - pdf
+      - doc
+      - txt
+      - rtf
+      - odt
+    state: updated
+  register: update_web_filetype_basic
+
+- name: ASSERTION CHECK FOR UPDATE WEB FILE TYPE BASIC
+  assert:
+    that: 
+      - update_web_filetype_basic is changed
+      - update_web_filetype_basic['api_response']['Response']['FileType']['Status']['@code'] == '200'
+      - "'Operation Successful' in update_web_filetype_basic['api_response']['Response']['FileType']['Status']['#text']"
+
+- name: QUERY UPDATED WEB FILE TYPE BASIC
+  sophos.sophos_firewall.sfos_web_filetype:
+    state: query
+    name: IGT-TEST-FILETYPE-BASIC
+  register: query_updated_web_filetype_basic
+
+- name: ASSERTION CHECK FOR QUERY UPDATED WEB FILE TYPE BASIC
+  assert:
+    that: 
+      - query_updated_web_filetype_basic is not changed
+      - query_updated_web_filetype_basic['api_response']['Response']['FileType']['Name'] == 'IGT-TEST-FILETYPE-BASIC'
+      - query_updated_web_filetype_basic['api_response']['Response']['FileType']['Description'] == 'Updated basic file type description'
+      - "'rtf' in query_updated_web_filetype_basic['api_response']['Response']['FileType']['FileExtensionList']['FileExtension']"
+      - "'odt' in query_updated_web_filetype_basic['api_response']['Response']['FileType']['FileExtensionList']['FileExtension']"
+
+- name: UPDATE WEB FILE TYPE BASIC NO CHANGE
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-BASIC
+    description: "Updated basic file type description"
+    file_extension:
+      - pdf
+      - doc
+      - txt
+      - rtf
+      - odt
+    state: updated
+  register: update_web_filetype_nochange
+
+- name: ASSERTION CHECK FOR UPDATE WEB FILE TYPE BASIC NO CHANGE
+  assert:
+    that: 
+      - update_web_filetype_nochange is not changed
+
+- name: CREATE WEB FILE TYPE WITH ONLY DESCRIPTION
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-DESC
+    description: "File type with only description for testing"
+    state: present
+  register: web_filetype_add_desc
+
+- name: ASSERTION CHECK FOR CREATE WEB FILE TYPE WITH DESCRIPTION ONLY
+  assert:
+    that: 
+      - web_filetype_add_desc is changed
+      - web_filetype_add_desc['api_response']['Response']['FileType']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in web_filetype_add_desc['api_response']['Response']['FileType']['Status']['#text']"
+
+- name: QUERY WEB FILE TYPE WITH DESCRIPTION ONLY
+  sophos.sophos_firewall.sfos_web_filetype:
+    state: query
+    name: IGT-TEST-FILETYPE-DESC
+  register: query_web_filetype_desc
+
+- name: ASSERTION CHECK FOR QUERY WEB FILE TYPE WITH DESCRIPTION ONLY
+  assert:
+    that: 
+      - query_web_filetype_desc is not changed
+      - query_web_filetype_desc['api_response']['Response']['FileType']['Name'] == 'IGT-TEST-FILETYPE-DESC'
+      - query_web_filetype_desc['api_response']['Response']['FileType']['Description'] == 'File type with only description for testing'
+
+- name: UPDATE WEB FILE TYPE ADVANCED WITH MIME HEADERS
+  sophos.sophos_firewall.sfos_web_filetype:
+    name: IGT-TEST-FILETYPE-ADVANCED
+    description: "Updated advanced file type with more MIME headers"
+    mime_header:
+      - image/jpeg
+      - image/png
+      - image/gif
+      - image/bmp
+      - image/webp
+    state: updated
+  register: update_web_filetype_advanced
+
+- name: ASSERTION CHECK FOR UPDATE WEB FILE TYPE ADVANCED
+  assert:
+    that: 
+      - update_web_filetype_advanced is changed
+      - update_web_filetype_advanced['api_response']['Response']['FileType']['Status']['@code'] == '200'
+      - "'Operation Successful' in update_web_filetype_advanced['api_response']['Response']['FileType']['Status']['#text']"
+
+- name: QUERY UPDATED WEB FILE TYPE ADVANCED
+  sophos.sophos_firewall.sfos_web_filetype:
+    state: query
+    name: IGT-TEST-FILETYPE-ADVANCED
+  register: query_updated_web_filetype_advanced
+
+- name: ASSERTION CHECK FOR QUERY UPDATED WEB FILE TYPE ADVANCED
+  assert:
+    that: 
+      - query_updated_web_filetype_advanced is not changed
+      - query_updated_web_filetype_advanced['api_response']['Response']['FileType']['Name'] == 'IGT-TEST-FILETYPE-ADVANCED'
+      - "'image/bmp' in query_updated_web_filetype_advanced['api_response']['Response']['FileType']['MIMEHeaderList']['MIMEHeader']"
+      - "'image/webp' in query_updated_web_filetype_advanced['api_response']['Response']['FileType']['MIMEHeaderList']['MIMEHeader']"
+
+# Removal is not possible at this time, the firewall returns 500: Operation could not be performed on Entity. 
+# This is a bug, once it is fixed we can reenable these tests. 
+
+# - name: REMOVE WEB FILE TYPE BASIC
+#   sophos.sophos_firewall.sfos_web_filetype:
+#     name: IGT-TEST-FILETYPE-BASIC
+#     state: absent
+#   register: remove_web_filetype_basic
+
+# - name: ASSERTION CHECK FOR REMOVE WEB FILE TYPE BASIC
+#   assert:
+#     that: 
+#       - remove_web_filetype_basic is changed
+#       - remove_web_filetype_basic['api_response']['Response']['FileType']['Status']['@code'] == "200"
+#       - remove_web_filetype_basic['api_response']['Response']['FileType']['Status']['#text'] == "Configuration applied successfully."
+
+# - name: REMOVE WEB FILE TYPE ADVANCED
+#   sophos.sophos_firewall.sfos_web_filetype:
+#     name: IGT-TEST-FILETYPE-ADVANCED
+#     state: absent
+#   register: remove_web_filetype_advanced
+
+# - name: ASSERTION CHECK FOR REMOVE WEB FILE TYPE ADVANCED
+#   assert:
+#     that: 
+#       - remove_web_filetype_advanced is changed
+#       - remove_web_filetype_advanced['api_response']['Response']['FileType']['Status']['@code'] == "200"
+#       - remove_web_filetype_advanced['api_response']['Response']['FileType']['Status']['#text'] == "Configuration applied successfully."
+
+# - name: REMOVE WEB FILE TYPE WITH DESCRIPTION ONLY
+#   sophos.sophos_firewall.sfos_web_filetype:
+#     name: IGT-TEST-FILETYPE-DESC
+#     state: absent
+#   register: remove_web_filetype_desc
+
+# - name: ASSERTION CHECK FOR REMOVE WEB FILE TYPE WITH DESCRIPTION ONLY
+#   assert:
+#     that: 
+#       - remove_web_filetype_desc is changed
+#       - remove_web_filetype_desc['api_response']['Response']['FileType']['Status']['@code'] == "200"
+#       - remove_web_filetype_desc['api_response']['Response']['FileType']['Status']['#text'] == "Configuration applied successfully."
+
+# - name: REMOVE NONEXISTING WEB FILE TYPE
+#   sophos.sophos_firewall.sfos_web_filetype:
+#     name: IGT-TEST-FILETYPE-NONEXISTENT
+#     state: absent
+#   register: remove_web_filetype_nonexistent
+
+# - name: ASSERTION CHECK FOR REMOVE NONEXISTING WEB FILE TYPE
+#   assert:
+#     that: 
+#       - remove_web_filetype_nonexistent is not changed
+#       - remove_web_filetype_nonexistent['api_response'] == "No. of records Zero."

--- a/tests/integration/targets/sfos_web_policy/aliases
+++ b/tests/integration/targets/sfos_web_policy/aliases
@@ -1,0 +1,1 @@
+gather_facts/no

--- a/tests/integration/targets/sfos_web_policy/tasks/main.yml
+++ b/tests/integration/targets/sfos_web_policy/tasks/main.yml
@@ -1,0 +1,469 @@
+# Copyright 2024 Sophos Ltd.  All rights reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+- name: CHECK REQUIRED VARS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure these variables are set in tests/integration/integration_config.yml: 
+      - ansible_user
+      - ansible_host
+      - ansible_password
+      - ansible_connection
+      - ansible_httpapi_validate_certs
+      - ansible_httpapi_port
+      - ansible_network_os
+      
+  when: ansible_user is not defined or
+        ansible_host is not defined or
+        ansible_password is not defined or
+        ansible_connection is not defined or
+        ansible_httpapi_validate_certs is not defined or
+        ansible_httpapi_port is not defined or
+        ansible_network_os is not defined
+
+- name: CHECK CONNECTION
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_connection is set to ansible.netcommon.httpapi in tests/integration/integration_config.yml
+      
+  when: ansible_connection != "ansible.netcommon.httpapi"
+
+- name: CHECK NETWORK_OS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_network_os is set to sophos.sophos_firewall.sfos in tests/integration/integration_config.yml
+      
+  when: ansible_network_os != "sophos.sophos_firewall.sfos"
+
+# PRE-TEST CLEANUP - Remove any objects that might be left from previous test runs
+- name: CLEANUP - REMOVE WEB POLICY BASIC
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-BASIC
+    state: absent
+  register: cleanup_basic
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB POLICY ADVANCED
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-ADVANCED
+    state: absent
+  register: cleanup_advanced
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB POLICY RULES
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-RULES
+    state: absent
+  register: cleanup_rules
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE WEB POLICY CLOUD
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-CLOUD
+    state: absent
+  register: cleanup_cloud
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE USER ASSIGNED WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-USER-ASSIGN
+    state: absent
+  ignore_errors: true
+
+# TEST 1: CREATE BASIC WEB FILTER POLICY
+- name: CREATE BASIC WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-BASIC
+    default_action: "Allow"
+    description: "Basic web filter policy for integration testing"
+    state: present
+  register: policy_add_basic
+
+- name: ASSERTION CHECK FOR CREATE BASIC POLICY
+  assert:
+    that: 
+      - policy_add_basic is changed
+      - policy_add_basic['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in policy_add_basic['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+- name: QUERY BASIC WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-BASIC
+    state: query
+  register: query_policy_basic
+
+- name: ASSERTION CHECK FOR QUERY BASIC POLICY
+  assert:
+    that: 
+      - query_policy_basic is not changed
+      - query_policy_basic['api_response']['Response']['WebFilterPolicy']['Name'] == 'IGT-TEST-POLICY-BASIC'
+      - query_policy_basic['api_response']['Response']['WebFilterPolicy']['DefaultAction'] == 'Allow'
+
+# TEST 2: CREATE ADVANCED WEB FILTER POLICY
+- name: CREATE ADVANCED WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-ADVANCED
+    default_action: "Deny"
+    download_file_size_restriction: 100
+    download_file_size_restriction_enabled: true
+    enable_reporting: "Enable"
+    youtube_filter_enabled: true
+    youtube_filter_is_strict: true
+    enforce_safe_search: true
+    enforce_image_licensing: true
+    quota_limit: 30
+    description: "Advanced web filter policy with content restrictions"
+    state: present
+  register: policy_add_advanced
+
+- name: ASSERTION CHECK FOR CREATE ADVANCED POLICY
+  assert:
+    that: 
+      - policy_add_advanced is changed
+      - policy_add_advanced['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in policy_add_advanced['api_response']['Response']['WebFilterPolicy']['Status']['#text'] or 'Unable to get status message' in policy_add_advanced['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+- name: QUERY ADVANCED WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-ADVANCED
+    state: query
+  register: query_policy_advanced
+
+- name: ASSERTION CHECK FOR QUERY ADVANCED POLICY
+  assert:
+    that: 
+      - query_policy_advanced is not changed
+      - query_policy_advanced['api_response']['Response']['WebFilterPolicy']['Name'] == 'IGT-TEST-POLICY-ADVANCED'
+      - query_policy_advanced['api_response']['Response']['WebFilterPolicy']['DefaultAction'] == 'Deny'
+
+# TEST 3: CREATE WEB FILTER POLICY WITH RULES
+- name: CREATE WEB FILTER POLICY WITH RULES
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-RULES
+    default_action: "Allow"
+    download_file_size_restriction: 200
+    enable_reporting: "Enable"
+    description: "Web filter policy with category rules"
+    rules:
+      - categories:
+          - id: "Social Networking"
+            type: "WebCategory"
+          - id: "Criminal Activity"
+            type: "WebCategory"
+        http_action: "Deny"
+        https_action: "Deny"
+        schedule: "All The Time"
+        policy_rule_enabled: true
+        ccl_rule_enabled: false
+      - categories:
+          - id: "Document Files"
+            type: "FileType"
+        http_action: "Allow"
+        https_action: "Allow"
+        policy_rule_enabled: true
+        ccl_rule_enabled: false
+    state: present
+  register: policy_add_rules
+
+- name: ASSERTION CHECK FOR CREATE POLICY WITH RULES
+  assert:
+    that: 
+      - policy_add_rules is changed
+      - policy_add_rules['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in policy_add_rules['api_response']['Response']['WebFilterPolicy']['Status']['#text'] or 'Unable to get status message' in policy_add_rules['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+- name: QUERY WEB FILTER POLICY WITH RULES
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-RULES
+    state: query
+  register: query_policy_rules
+
+- name: ASSERTION CHECK FOR QUERY POLICY WITH RULES
+  assert:
+    that: 
+      - query_policy_rules is not changed
+      - query_policy_rules['api_response']['Response']['WebFilterPolicy']['Name'] == 'IGT-TEST-POLICY-RULES'
+      - query_policy_rules['api_response']['Response']['WebFilterPolicy']['DefaultAction'] == 'Allow'
+
+# TEST 4: CREATE WEB FILTER POLICY WITH CLOUD SERVICES
+- name: CREATE WEB FILTER POLICY WITH CLOUD SERVICES
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-CLOUD
+    default_action: "Allow"
+    download_file_size_restriction: 500
+    enable_reporting: "Enable"
+    goog_app_domain_list: "example.com,test.org"
+    goog_app_domain_list_enabled: true
+    office_365_tenants_list: "tenant1.onmicrosoft.com"
+    office_365_enabled: true
+    xff_enabled: true
+    description: "Policy for cloud services access"
+    state: present
+  register: policy_add_cloud
+
+- name: ASSERTION CHECK FOR CREATE CLOUD POLICY
+  assert:
+    that: 
+      - policy_add_cloud is changed
+      - policy_add_cloud['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in policy_add_cloud['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+- name: QUERY CLOUD WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-CLOUD
+    state: query
+  register: query_policy_cloud
+
+- name: ASSERTION CHECK FOR QUERY CLOUD POLICY
+  assert:
+    that: 
+      - query_policy_cloud is not changed
+      - query_policy_cloud['api_response']['Response']['WebFilterPolicy']['Name'] == 'IGT-TEST-POLICY-CLOUD'
+      - query_policy_cloud['api_response']['Response']['WebFilterPolicy']['DefaultAction'] == 'Allow'
+
+# TEST 5: UPDATE BASIC WEB FILTER POLICY
+- name: UPDATE BASIC WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-BASIC
+    default_action: "Deny"
+    download_file_size_restriction: 75
+    description: "Updated basic web filter policy"
+    state: updated
+  register: update_policy_basic
+
+- name: ASSERTION CHECK FOR UPDATE BASIC POLICY
+  assert:
+    that: 
+      - update_policy_basic is changed
+      - update_policy_basic['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_policy_basic['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# TEST 6: UPDATE POLICY WITH RULE REPLACEMENT
+- name: UPDATE POLICY WITH RULE REPLACEMENT
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-RULES
+    description: "Updated policy with replaced rules"
+    rules:
+      - categories:
+          - id: "Advertisements"
+            type: "WebCategory"
+        http_action: "Deny"
+        https_action: "Deny"
+        policy_rule_enabled: true
+        ccl_rule_enabled: false
+    rule_action: "replace"
+    state: updated
+  register: update_policy_replace_rules
+
+- name: ASSERTION CHECK FOR UPDATE POLICY WITH RULE REPLACEMENT
+  assert:
+    that: 
+      - update_policy_replace_rules is changed
+      - update_policy_replace_rules['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_policy_replace_rules['api_response']['Response']['WebFilterPolicy']['Status']['#text'] or 'Unable to get status message' in update_policy_replace_rules['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# TEST 7: UPDATE POLICY WITH RULE ADDITION
+- name: UPDATE POLICY WITH RULE ADDITION
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-RULES
+    description: "Updated policy with additional rules"
+    rules:
+      - categories:
+          - id: "Spam URLs"
+            type: "WebCategory"
+        http_action: "Deny"
+        https_action: "Deny"
+        policy_rule_enabled: true
+        ccl_rule_enabled: false
+    rule_action: "add"
+    state: updated
+  register: update_policy_add_rules
+
+- name: ASSERTION CHECK FOR UPDATE POLICY WITH RULE ADDITION
+  assert:
+    that: 
+      - update_policy_add_rules is changed
+      - update_policy_add_rules['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_policy_add_rules['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# TEST 8: UPDATE ADVANCED POLICY WITH ALL OPTIONS
+- name: UPDATE ADVANCED POLICY WITH ALL OPTIONS
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-ADVANCED
+    default_action: "Allow"
+    download_file_size_restriction: 150
+    download_file_size_restriction_enabled: false
+    youtube_filter_enabled: false
+    youtube_filter_is_strict: false
+    enforce_safe_search: false
+    enforce_image_licensing: false
+    quota_limit: 60
+    description: "Updated advanced policy with modified settings"
+    state: updated
+  register: update_policy_advanced_all
+
+- name: ASSERTION CHECK FOR UPDATE ADVANCED POLICY ALL OPTIONS
+  assert:
+    that: 
+      - update_policy_advanced_all is changed
+      - update_policy_advanced_all['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_policy_advanced_all['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# TEST 9: UPDATE CLOUD POLICY
+- name: UPDATE CLOUD POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-CLOUD
+    goog_app_domain_list: "newdomain.com,updated.org"
+    goog_app_domain_list_enabled: false
+    office_365_tenants_list: "newtenant.onmicrosoft.com,updated-tenant.onmicrosoft.com"
+    office_365_enabled: false
+    xff_enabled: false
+    description: "Updated cloud services policy"
+    state: updated
+  register: update_policy_cloud
+
+- name: ASSERTION CHECK FOR UPDATE CLOUD POLICY
+  assert:
+    that: 
+      - update_policy_cloud is changed
+      - update_policy_cloud['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_policy_cloud['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# TEST 10: CREATE POLICY WITH MIXED RULE TYPES
+- name: CREATE POLICY WITH MIXED RULE TYPES
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-MIXED
+    default_action: "Deny"
+    download_file_size_restriction: 250
+    enable_reporting: "Enable"
+    description: "Policy with mixed rule category types"
+    rules:
+      - categories:
+          - id: "Social Networking"
+            type: "WebCategory"
+          - id: "Audio Files"
+            type: "FileType"
+        http_action: "Deny"
+        https_action: "Deny"
+        follow_http_action: true
+        schedule: "All The Time"
+        policy_rule_enabled: true
+        ccl_rule_enabled: false
+    state: present
+  register: policy_add_mixed
+
+
+- name: ASSERTION CHECK FOR CREATE MIXED POLICY
+  assert:
+    that: 
+      - policy_add_mixed is changed
+      - policy_add_mixed['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in policy_add_mixed['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# TEST 11: CREATE POLICY ASSIGNED TO DIFFERENT USERS
+- name: CREATE POLICY ASSIGNED TO DIFFERENT USERS
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-USER-ASSIGN
+    default_action: "Deny"
+    download_file_size_restriction: 250
+    enable_reporting: "Enable"
+    description: "Policy with mixed rule category types"
+    rules:
+      - categories:
+          - id: "Extreme"
+            type: "WebCategory"
+          - id: "Video Files"
+            type: "FileType"
+        http_action: "Deny"
+        https_action: "Deny"
+        follow_http_action: true
+        schedule: "All The Time"
+        policy_rule_enabled: true
+        user_list:
+          - "Guest Group"
+          - "Unknown Users"
+        ccl_rule_enabled: false
+    state: present
+  register: policy_add_user_assign
+
+
+- name: ASSERTION CHECK FOR CREATE USER ASSIGN POLICY
+  assert:
+    that: 
+      - policy_add_user_assign is changed
+      - policy_add_user_assign['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in policy_add_user_assign['api_response']['Response']['WebFilterPolicy']['Status']['#text']"
+
+# FINAL CLEANUP - Remove all test objects
+- name: REMOVE BASIC WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-BASIC
+    state: absent
+  register: remove_policy_basic
+
+- name: ASSERTION CHECK FOR REMOVE BASIC POLICY
+  assert:
+    that: 
+      - remove_policy_basic is changed
+      - remove_policy_basic['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+
+- name: REMOVE ADVANCED WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-ADVANCED
+    state: absent
+  register: remove_policy_advanced
+
+- name: ASSERTION CHECK FOR REMOVE ADVANCED POLICY
+  assert:
+    that: 
+      - remove_policy_advanced is changed
+      - remove_policy_advanced['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+
+- name: REMOVE RULES WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-RULES
+    state: absent
+  register: remove_policy_rules
+
+- name: ASSERTION CHECK FOR REMOVE RULES POLICY
+  assert:
+    that: 
+      - remove_policy_rules is changed
+      - remove_policy_rules['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+
+- name: REMOVE CLOUD WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-CLOUD
+    state: absent
+  register: remove_policy_cloud
+
+- name: ASSERTION CHECK FOR REMOVE CLOUD POLICY
+  assert:
+    that: 
+      - remove_policy_cloud is changed
+      - remove_policy_cloud['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+
+- name: REMOVE MIXED WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-MIXED
+    state: absent
+  register: remove_policy_mixed
+
+- name: ASSERTION CHECK FOR REMOVE MIXED POLICY
+  assert:
+    that: 
+      - remove_policy_mixed is changed
+      - remove_policy_mixed['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'
+
+- name: REMOVE USER ASSIGNED WEB FILTER POLICY
+  sophos.sophos_firewall.sfos_web_policy:
+    name: IGT-TEST-POLICY-USER-ASSIGN
+    state: absent
+  register: remove_user_assigned
+
+- name: ASSERTION CHECK FOR REMOVE USER ASSIGNED POLICY
+  assert:
+    that: 
+      - remove_user_assigned is changed
+      - remove_user_assigned['api_response']['Response']['WebFilterPolicy']['Status']['@code'] == '200'

--- a/tests/integration/targets/sfos_web_useractivity/aliases
+++ b/tests/integration/targets/sfos_web_useractivity/aliases
@@ -1,0 +1,1 @@
+gather_facts/no

--- a/tests/integration/targets/sfos_web_useractivity/tasks/main.yml
+++ b/tests/integration/targets/sfos_web_useractivity/tasks/main.yml
@@ -1,0 +1,219 @@
+# Copyright 2024 Sophos Ltd.  All rights reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+- name: CHECK REQUIRED VARS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure these variables are set in tests/integration/integration_config.yml: 
+      - ansible_user
+      - ansible_host
+      - ansible_password
+      - ansible_connection
+      - ansible_httpapi_validate_certs
+      - ansible_httpapi_port
+      - ansible_network_os
+      
+  when: ansible_user is not defined or
+        ansible_host is not defined or
+        ansible_password is not defined or
+        ansible_connection is not defined or
+        ansible_httpapi_validate_certs is not defined or
+        ansible_httpapi_port is not defined or
+        ansible_network_os is not defined
+
+- name: CHECK CONNECTION
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_connection is set to ansible.netcommon.httpapi in tests/integration/integration_config.yml
+      
+  when: ansible_connection != "ansible.netcommon.httpapi"
+
+- name: CHECK NETWORK_OS
+  ansible.builtin.fail:
+    msg: | 
+      Please ensure ansible_network_os is set to sophos.sophos_firewall.sfos in tests/integration/integration_config.yml
+      
+  when: ansible_network_os != "sophos.sophos_firewall.sfos"
+
+# PRE-TEST CLEANUP - Remove any objects that might be left from previous test runs
+- name: CLEANUP - REMOVE USER ACTIVITY BASIC
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-BASIC
+    state: absent
+  register: cleanup_basic
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE USER ACTIVITY MIXED
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-MIXED
+    state: absent
+  register: cleanup_mixed
+  ignore_errors: true
+
+- name: CLEANUP - REMOVE USER ACTIVITY SIMPLE
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-SIMPLE
+    state: absent
+  register: cleanup_simple
+  ignore_errors: true
+
+- name: PAUSE AFTER CLEANUP
+  pause:
+    seconds: 3
+  when: cleanup_basic.changed or cleanup_mixed.changed or cleanup_simple.changed
+
+- name: CREATE USER ACTIVITY WITH WEB CATEGORIES
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-BASIC
+    description: "Basic user activity for integration testing"
+    category_list:
+      - id: "Advertisements"
+        type: "web category"
+      - id: "Criminal Activity"
+        type: "web category"
+    state: present
+  register: useractivity_add_basic
+
+- name: ASSERTION CHECK FOR CREATE USER ACTIVITY BASIC
+  assert:
+    that: 
+      - useractivity_add_basic is changed
+      - useractivity_add_basic['api_response']['Response']['UserActivity']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in useractivity_add_basic['api_response']['Response']['UserActivity']['Status']['#text']"
+
+- name: QUERY USER ACTIVITY BASIC
+  sophos.sophos_firewall.sfos_web_useractivity:
+    state: query
+    name: IGT-TEST-USERACTIVITY-BASIC
+  register: query_useractivity_basic
+
+- name: ASSERTION CHECK FOR QUERY USER ACTIVITY BASIC
+  assert:
+    that: 
+      - query_useractivity_basic is not changed
+      - query_useractivity_basic['api_response']['Response']['UserActivity']['Name'] == 'IGT-TEST-USERACTIVITY-BASIC'
+      - query_useractivity_basic['api_response']['Response']['UserActivity']['Desc'] == 'Basic user activity for integration testing'
+
+- name: CREATE USER ACTIVITY WITH MIXED CATEGORIES
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-MIXED
+    description: "Mixed category user activity for integration testing"
+    category_list:
+      - id: "Social Networking"
+        type: "web category"
+      - id: "Document Files"
+        type: "file type"
+    state: present
+  register: useractivity_add_mixed
+
+- name: ASSERTION CHECK FOR CREATE USER ACTIVITY MIXED
+  assert:
+    that: 
+      - useractivity_add_mixed is changed
+      - useractivity_add_mixed['api_response']['Response']['UserActivity']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in useractivity_add_mixed['api_response']['Response']['UserActivity']['Status']['#text']"
+
+- name: QUERY USER ACTIVITY MIXED
+  sophos.sophos_firewall.sfos_web_useractivity:
+    state: query
+    name: IGT-TEST-USERACTIVITY-MIXED
+  register: query_useractivity_mixed
+
+- name: ASSERTION CHECK FOR QUERY USER ACTIVITY MIXED
+  assert:
+    that: 
+      - query_useractivity_mixed is not changed
+      - query_useractivity_mixed['api_response']['Response']['UserActivity']['Name'] == 'IGT-TEST-USERACTIVITY-MIXED'
+      - query_useractivity_mixed['api_response']['Response']['UserActivity']['Desc'] == 'Mixed category user activity for integration testing'
+
+- name: UPDATE USER ACTIVITY BASIC
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-BASIC
+    description: "Updated basic user activity description"
+    category_list:
+      - id: "Advertisements"
+        type: "web category"
+      - id: "Criminal Activity"
+        type: "web category"
+      - id: "Spam URLs"
+        type: "web category"
+    state: updated
+  register: update_useractivity_basic
+
+- name: ASSERTION CHECK FOR UPDATE USER ACTIVITY BASIC
+  assert:
+    that: 
+      - update_useractivity_basic is changed
+      - update_useractivity_basic['api_response']['Response']['UserActivity']['Status']['@code'] == '200'
+      - "'Configuration applied successfully' in update_useractivity_basic['api_response']['Response']['UserActivity']['Status']['#text']"
+
+- name: QUERY UPDATED USER ACTIVITY BASIC
+  sophos.sophos_firewall.sfos_web_useractivity:
+    state: query
+    name: IGT-TEST-USERACTIVITY-BASIC
+  register: query_updated_useractivity_basic
+
+- name: ASSERTION CHECK FOR QUERY UPDATED USER ACTIVITY BASIC
+  assert:
+    that: 
+      - query_updated_useractivity_basic is not changed
+      - query_updated_useractivity_basic['api_response']['Response']['UserActivity']['Name'] == 'IGT-TEST-USERACTIVITY-BASIC'
+      - query_updated_useractivity_basic['api_response']['Response']['UserActivity']['Desc'] == 'Updated basic user activity description'
+
+- name: UPDATE USER ACTIVITY BASIC NO CHANGE
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-BASIC
+    description: "Updated basic user activity description"
+    category_list:
+      - id: "Advertisements"
+        type: "web category"
+      - id: "Criminal Activity"
+        type: "web category"
+      - id: "Spam URLs"
+        type: "web category"
+    state: updated
+  register: update_useractivity_nochange
+
+- name: ASSERTION CHECK FOR UPDATE USER ACTIVITY BASIC NO CHANGE
+  assert:
+    that: 
+      - update_useractivity_nochange is not changed
+
+- name: REMOVE USER ACTIVITY BASIC
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-BASIC
+    state: absent
+  register: remove_useractivity_basic
+
+- name: ASSERTION CHECK FOR REMOVE USER ACTIVITY BASIC
+  assert:
+    that: 
+      - remove_useractivity_basic is changed
+      - remove_useractivity_basic['api_response']['Response']['UserActivity']['Status']['@code'] == "200"
+      - remove_useractivity_basic['api_response']['Response']['UserActivity']['Status']['#text'] == "Configuration applied successfully."
+
+- name: REMOVE USER ACTIVITY MIXED
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-MIXED
+    state: absent
+  register: remove_useractivity_mixed
+
+- name: ASSERTION CHECK FOR REMOVE USER ACTIVITY MIXED
+  assert:
+    that: 
+      - remove_useractivity_mixed is changed
+      - remove_useractivity_mixed['api_response']['Response']['UserActivity']['Status']['@code'] == "200"
+      - remove_useractivity_mixed['api_response']['Response']['UserActivity']['Status']['#text'] == "Configuration applied successfully."
+
+- name: REMOVE NONEXISTING USER ACTIVITY
+  sophos.sophos_firewall.sfos_web_useractivity:
+    name: IGT-TEST-USERACTIVITY-NONEXISTENT
+    state: absent
+  register: remove_useractivity_nonexistent
+
+- name: ASSERTION CHECK FOR REMOVE NONEXISTING USER ACTIVITY
+  assert:
+    that: 
+      - remove_useractivity_nonexistent is not changed
+      - remove_useractivity_nonexistent['api_response'] == "No. of records Zero."


### PR DESCRIPTION
Added modules:
- sfos_web_policy
- sfos_web_category
- sfos_web_filetype
-  sfos_web_useractivity
-  sfos_qos_policy

Updated sfos_firewall_rule to support attaching web and qos policies to rules, and to support multiple additional configuration parameters: 

            web_filter(str): Name of the web filter policy to apply
            web_category_traffic_shaping(str): Name of the web category traffic shaping policy to apply
            block_quic(str): Enable/Disable QUIC blocking
            scan_virus(str): Enable/Disable virus scanning
            proxy_mode(str): Enable/Disable proxy mode
            decrypt_https(str): Enable/Disable HTTPS decryption
            source_security_heartbeat(str): Enable/Disable source security heartbeat
            minimum_source_hb_permitted(str): Minimum source heartbeat permitted
            dest_security_heartbeat(str): Enable/Disable destination security heartbeat
            minimum_dest_hb_permitted(str): Minimum destination heartbeat permitted
            application_control(str): Enable/Disable application control
            application_base_qos_policy(str): Name of the application base QoS policy to apply
            intrusion_prevention(str): Enable/Disable intrusion prevention
            qos_policy(str): Name of the QoS traffic shaping policy to apply
            dscp_marking(str): DSCP marking value
            scan_smtp(str): Enable/Disable SMTP scanning
            scan_smtps(str): Enable/Disable SMTPS scanning
            scan_imap(str): Enable/Disable IMAP scanning
            scan_imaps(str): Enable/Disable IMAPS scanning
            scan_pop3(str): Enable/Disable POP3 scanning
            scan_pop3s(str): Enable/Disable POP3S scanning